### PR TITLE
Take care of setting `sonatypeProjectHosting` so projects don't need to

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -140,7 +140,7 @@ jobs:
 
   create-artifacts:
     name: 🎊 Create artifacts
-    needs: push-release-commit
+    needs: [identifiers-for-signing-key, push-release-commit]
     runs-on: ubuntu-latest
     outputs:
       ARTIFACT_SHA256SUMS: ${{ steps.record-hashes.outputs.ARTIFACT_SHA256SUMS }}
@@ -153,7 +153,14 @@ jobs:
           distribution: corretto
           java-version: 17
       - name: Generate artifacts
-        run: sbt ";set ThisBuild / publishTo := Some(Resolver.file(\"foobar\", file(\"$LOCAL_ARTIFACTS_STAGING_PATH\"))); +publish"
+        run: |
+          cat << EndOfFile > sbt-commands.txt
+          set every sonatypeProjectHosting := Some(xerial.sbt.Sonatype.GitHubHosting("$GITHUB_REPOSITORY_OWNER", "${GITHUB_REPOSITORY#*/}", "${{ needs.identifiers-for-signing-key.outputs.key_email }}"))
+          set ThisBuild / publishTo := Some(Resolver.file("foobar", file("$LOCAL_ARTIFACTS_STAGING_PATH")))
+          EndOfFile
+          cat sbt-commands.txt
+          
+          sbt ";< sbt-commands.txt; +publish"
       - name: Record SHA-256 hashes of artifacts
         id: record-hashes
         run: |


### PR DESCRIPTION
This metadata is essential, otherwise Sonatype will reject the submission and it won't make it to Maven Central:

https://central.sonatype.org/publish/requirements/#project-name-description-and-url

```
2023-12-08 12:05:49.783Z error [SonatypeClient]     Failed: pom-staging, failureMessage:Invalid POM: /com/gu/play-googleauth/play-v29_2.13/3.0.2/play-v29_2.13-3.0.2.pom: Project URL missing, SCM URL missing, Developer information missing  - (SonatypeClient.scala:387)
```

Note that for setting `sonatypeProjectHosting`, neither using the `ThisBuild` or `Global` would work:

```
set ThisBuild / sonatypeProjectHosting
```

or

```
set Global / sonatypeProjectHosting
```

...both gave an error like this:

```
[info] Defining ThisBuild / sonatypeProjectHosting
[info] The new value will be used by no settings or tasks.
```
https://github.com/guardian/play-googleauth/actions/runs/7140777885/job/19446776922#step:4:29

...using `set every` (as in `set every sonatypeProjectHosting`) is something I never had
 even heard of before, but it works, and sets the subproject settings.

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
