### PR TITLE
Document that `license` is a required setting

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -54,6 +54,9 @@ to the workflow.
   suffix. You can think of `-SNAPSHOT` as meaning 'a snapshot preview' - so when you're working on `1.4.7-SNAPSHOT`,
   you're working on a _preview_ of the forthcoming `1.4.7` release. The workflow will automatically update the `version`
   during each release, as appropriate.
+* `licenses := Seq(License.Apache2)` - or whatever license you're using. Specifying a license is
+  [*required*](https://central.sonatype.org/publish/requirements/#license-information) for submitting artifacts
+  to Maven Central.
 * `releaseVersion := fromAggregatedAssessedCompatibilityWithLatestRelease().value` - to activate the
   automatic compatibility-based version-numbering provided by the `sbt-version-policy` plugin. This means your `version`
   can go up by more than just an `x.x.PATCH` increment in a release, if


### PR DESCRIPTION
We had a [failed release](https://github.com/guardian/targeting-client/actions/runs/7299896704/job/19893644176#step:5:56) on [`guardian/targeting-client`](https://github.com/guardian/targeting-client) after https://github.com/guardian/targeting-client/pull/37 accidentally removed the `license` setting:

> 2023-12-22 12:37:31.246Z error [SonatypeClient]     Failed: pom-staging, failureMessage:Invalid POM: /com/gu/targeting-client/client-play-json-v30_2.13/1.1.5/client-play-json-v30_2.13-1.1.5.pom: **License information missing**  - (SonatypeClient.scala:387)

Specifying a license is [*required*](https://central.sonatype.org/publish/requirements/#license-information) for submitting a project to Maven Central, so we see the error above if we omit the setting.

Note that sbt [v1.6.2](https://github.com/sbt/sbt/releases/tag/v1.6.2) and above (thanks to https://github.com/sbt/librarymanagement/pull/395) supply a `License` object that means you can define the license much more concisely:

```sbt
licenses := Seq(License.Apache2)
```

_(used successfully in https://github.com/guardian/etag-caching/pull/29)_
