### PR TITLE
Docs: setting the `groupId` with `organisation`

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -54,6 +54,10 @@ to the workflow.
   suffix. You can think of `-SNAPSHOT` as meaning 'a snapshot preview' - so when you're working on `1.4.7-SNAPSHOT`,
   you're working on a _preview_ of the forthcoming `1.4.7` release. The workflow will automatically update the `version`
   during each release, as appropriate.
+* `organization` - this dictates the [groupId](https://maven.apache.org/guides/mini/guide-naming-conventions.html) of
+  your artifacts, and can be either the same as your Sonatype account profile name (eg `com.gu` for the Guardian),
+  or a dot-suffixed version of it (eg `com.gu.foobar`) if your project ('foobar') releases multiple artifacts
+  [_(details)_](https://github.com/guardian/gha-scala-library-release-workflow/pull/15)
 * `licenses := Seq(License.Apache2)` - or whatever license you're using. Specifying a license is
   [*required*](https://central.sonatype.org/publish/requirements/#license-information) for submitting artifacts
   to Maven Central.


### PR DESCRIPTION
It's crucial to set the group id, otherwise we won't know what the artifact coordinates should be!

- https://maven.apache.org/guides/mini/guide-naming-conventions.html
- https://www.scala-sbt.org/1.x/docs/Library-Dependencies.html#The++key
- https://www.scala-sbt.org/1.x/docs/Publishing.html#Publishing+locally

`organisation` & `sonatypeProfileName` are two related `sbt` settings, which may sometimes have identical values, but which `gha-scala-library-release-workflow` makes users set in two different ways:

* `organisation` - a core sbt setting, that dictates groupId for published artifacts. `gha-scala-library-release-workflow` expects this to be **set in the user's `build.sbt`** file. It's wise for it to be set there, as it will ensure the user can successfully run `publishLocal` on their own laptop (which won't involve `gha-scala-library-release-workflow`)
* `sonatypeProfileName` - a `sbt-sonatype` setting that relates to _authorisation_ for uploading artifacts with that groupId prefix to oss.sonatype.org and thus to Maven Central. `gha-scala-library-release-workflow` takes this as a **workflow input parameter** called `SONATYPE_PROFILE_NAME` - this setting is _not_ needed for `publishLocal`, only for actually uploading a release to oss.sonatype.org, which we no longer expect users to do on their own laptops - so it _can_ be a workflow-only setting - and likely with an organisation-wide default value, that means users have one less thing to configure per-project.

If you own the Sonatype account profile name of, eg, `com.gu`, you control all sub-group-ids under that name - and that is useful for projects that release many artifacts at once, as it can neatly group all those artifacts together (eg `com.gu.etag-caching`, `com.gu.play-googleauth`).

From https://central.sonatype.org/publish/requirements/coordinates/ :

> When we grant permissions at the top-level groupId, like io.github.example, you can publish any components under that groupId or any sub-groups that look like io.github.example.mysubgroup1 or io.github.example.android.

This means that the `SONATYPE_PROFILE_NAME` will likely be identical for all the projects under an GitHub org (eg `com.gu` for everything at the Guardian), whereas different projects in the GitHub org may well have differing sub-group-ids (so different `organisation` settings in each project).

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->
