### PR TITLE
Give earlier warning when PGP key is misconfigured

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -61,6 +61,10 @@ jobs:
           key_fingerprint=$key_fingerprint
           key_email=$key_email
           EndOfFile
+          if ! [[ "$key_fingerprint" =~ ^[[:xdigit:]]{8,}$ ]]; then
+            echo "::error title=Missing PGP key::Has PGP_PRIVATE_KEY been set correctly? https://github.com/guardian/gha-scala-library-release-workflow/blob/main/docs/credentials/supplying-credentials.md"
+            exit 1
+          fi
       - name: Check for default branch
         id: generate-version-suffix
         env:


### PR DESCRIPTION
The workflow should fail sooner when the PGP key is misconfigured (usually because of missing access to a secret).

Related: https://github.com/guardian/gha-scala-library-release-workflow/issues/17

There should ideally also be an early fatal error if the key is passphrase-protected, we only support passphrase-less PGP keys - https://security.stackexchange.com/a/183657/67781 probably gives the best advice on how to test if a key is properly passphrase-less. Something to try in a new PR.
