### PR TITLE
Explicitly switch to Sonatype token authentication

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -20,14 +20,9 @@ on:
         default: 'oss.sonatype.org' # The default host is going to be whatever "com.gu" is using
         required: false # ...but if you're not the Guardian, you'll want to set this explicitly
         type: string
-      SONATYPE_USERNAME:
-        description: 'Sonatype username'
-        default: 'guardian.automated.maven.release' # Only for use by the Guardian!
-        required: false # Must be supplied if used by a non-Guardian project
-        type: string
     secrets:
-      SONATYPE_PASSWORD:
-        description: 'Password for the SONATYPE_USERNAME account - used to authenticate when uploading artifacts'
+      SONATYPE_TOKEN:
+        description: 'Sonatype authentication token, colon-separated (username:password) - https://central.sonatype.org/publish/generate-token/'
         required: true
       PGP_PRIVATE_KEY:
         description:
@@ -416,9 +411,10 @@ jobs:
           cache: sbt # the issue described in https://github.com/actions/setup-java/pull/564 doesn't affect this step (no version.sbt)
       - name: Release
         env:
-          SONATYPE_USERNAME: ${{ inputs.SONATYPE_USERNAME }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          SONATYPE_TOKEN: ${{ secrets.SONATYPE_TOKEN }}
         run: |
+          export SONATYPE_USERNAME="${SONATYPE_TOKEN%%:*}" # See https://github.com/xerial/sbt-sonatype/pull/62
+          export SONATYPE_PASSWORD="${SONATYPE_TOKEN#*:}"
           sbt "sonatypeBundleRelease"
 
   github-release:

--- a/docs/credentials/generating-credentials.md
+++ b/docs/credentials/generating-credentials.md
@@ -3,9 +3,25 @@
 Normally you'll be using [shared organisation-wide credentials](supplying-credentials.md),
 but if you need to rotate those credentials, or just create some new ones for your organisation:
 
-## Updating a Sonatype OSSRH user's password
+## Updating a Sonatype OSSRH Token username & password
 
-See [Sonatype's instructions](https://central.sonatype.org/faq/ossrh-password/).
+As of [January 2024](https://central.sonatype.org/news/20240109_issues_sonatype_org_deprecation/#support-requests),
+Sonatype is actively discouraging the legacy username & password method of authentication, recommending
+[token authentication](https://central.sonatype.org/publish/generate-token/)
+(see link for token-regenerating instructions).
+
+Note these points:
+
+* The token is in a colon:separated username/password format, and _both_ username & password are randomised & revocable
+  secret strings.
+* Tokens generated on either https://oss.sonatype.org/ or https://s01.oss.sonatype.org/ will be _different_, and
+  **a token generated on one will not work on the other**. So, eg, if your `SONATYPE_CREDENTIAL_HOST` is `s01.oss.sonatype.org`,
+  you'll need to use a token _generated_ on `s01.oss.sonatype.org`. Remember that the `SONATYPE_CREDENTIAL_HOST` you
+  use is [dictated](https://github.com/xerial/sbt-sonatype/pull/461) by which Sonatype OSSRH server your **profile**
+  is hosted on.  
+  **Guardian developers:** currently the Guardian's `com.gu` profile is hosted on `oss.sonatype.org`, so the token we
+  use must be generated [there](https://oss.sonatype.org/), logged in with the `guardian.automated.maven.release`
+  account.
 
 ## Generating a new PGP key
 

--- a/docs/credentials/supplying-credentials.md
+++ b/docs/credentials/supplying-credentials.md
@@ -20,7 +20,7 @@ has _access_ to those secrets.
 to grant repos access to the necessary Organisation secrets - you need to raise a PR (like [this example PR](https://github.com/guardian/github-secret-access/pull/24))
 which will grant access to these:
 
-* `AUTOMATED_MAVEN_RELEASE_SONATYPE_PASSWORD`
+* `AUTOMATED_MAVEN_RELEASE_SONATYPE_TOKEN`
 * `AUTOMATED_MAVEN_RELEASE_PGP_SECRET`
 * `AUTOMATED_MAVEN_RELEASE_GITHUB_APP_PRIVATE_KEY`
 


### PR DESCRIPTION
This PR fixes #39, updating `gha-scala-library-release-workflow` to take a single colon-separated [composite API token](https://central.sonatype.org/publish/generate-token/) (`username:password`) for auth, rather than the old Nexus UI username & password combination, which is now rejected by Sonatype.

## Changes required to repos using `gha-scala-library-release-workflow`

All repos need to update their `.github/workflows/release.yml` to use the workflow's new `SONATYPE_TOKEN` parameter (the old `SONATYPE_PASSWORD` parameter has been dropped):

#### Before
```
SONATYPE_PASSWORD: ${{ secrets.AUTOMATED_MAVEN_RELEASE_SONATYPE_PASSWORD }}
```
#### After

```
SONATYPE_TOKEN: ${{ secrets.AUTOMATED_MAVEN_RELEASE_SONATYPE_TOKEN }}
```

#### Updating many projects at once

As in https://github.com/guardian/gha-scala-library-release-workflow/pull/36, it was possible to update many of the [~30 projects using `gha-scala-library-release-workflow`](https://github.com/guardian/gha-scala-library-release-workflow/issues/20) using a [switch-release-yml-to-token-auth.sh](https://gist.github.com/rtyley/2ab9f5e591ccead15d069cb43c7ca87f) script that I hammered together:

```bash
cd ~/code/github-secret-access ; grep MAVEN_RELEASE_CREDENTIALS access.ts | grep ": "  | cut -d'"' -f2  > ../release-repos.txt

./switch-release-yml-to-token-auth.sh release-repos.txt
```


## Testing

An example of a successful release with this change (at commit 23a148a03cf71bb2093a91f047d3c368adcdf45c) is:

https://github.com/guardian/etag-caching/actions/runs/9588801840


## See also

* https://github.com/guardian/github-secret-access/pull/55
* https://github.com/xerial/sbt-sonatype/pull/464
* https://chat.google.com/room/AAAAag0I08g/Oi-XzrQ-GWM/Oi-XzrQ-GWM

