### PR TITLE
Output release version to caller workflow

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -28,6 +28,10 @@ on:
           Should be in normal plaintext 'BEGIN PGP PUBLIC KEY BLOCK' (ASCII-armored) format, with no additional BASE64-encoding.
           The passphrase can be removed from an existing key using 'gpg --edit-key <key-id> passwd' : https://unix.stackexchange.com/a/550538/46453"
         required: true
+    outputs:
+      RELEASE_VERSION:
+        description: "The un-prefixed version number of the release, eg '3.0.1'"
+        value: ${{ jobs.push-release-commit.outputs.release_version }}
 
 env:
   LOCAL_ARTIFACTS_STAGING_PATH: /tmp/artifact_staging


### PR DESCRIPTION
Some projects output both Scala and NPM libraries with a single release - for example, we need to support this in content-api-models: https://github.com/guardian/content-api-models/pull/232

Rather than try to teach gha-scala-library-release-workflow how to do NPM releases, it seems better to let the workflow do the Scala release, and then output the release version number so that it can be used by a subsequent custom 'npm release' stage of caller workflow.

See also: https://docs.github.com/en/actions/using-workflows/reusing-workflows#using-outputs-from-a-reusable-workflow
