### PR TITLE
Remove underscores from PREVIEW version-numbers, complying with SemVer and fixing for `sbt-release`

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -84,7 +84,7 @@ jobs:
             version_suffix=""
           else
             release_type="PREVIEW_FEATURE_BRANCH"
-            version_suffix="-PREVIEW.${GITHUB_REF_NAME//[^[:alnum:]-_]/}.$(date +%Y-%m-%dT%H%M).${GITHUB_SHA:0:8}"
+            version_suffix="-PREVIEW.${GITHUB_REF_NAME//[^[:alnum:]-]/}.$(date +%Y-%m-%dT%H%M).${GITHUB_SHA:0:8}"
           fi
           echo "current branch: $GITHUB_REF_NAME, release_type: $release_type, version_suffix: $version_suffix"
           cat << EndOfFile >> $GITHUB_OUTPUT


### PR DESCRIPTION
The branch name of `update/non_aws` caused problems with the PREVIEW release workflow in [this recent release run](https://github.com/guardian/atom-maker/actions/runs/7905475560/job/21578205513#step:4:66) for https://github.com/guardian/atom-maker/pull/96 - we saw this error from `sbt-release`:

```
Version [3.0.0-PREVIEW.updatenon_aws.2024-02-14T1807.431c7567] format is not compatible with ([0-9]+)((?:\.[0-9]+)+)?([\.\-0-9a-zA-Z]*)?
```

You can see that the existing branch-name-cleanup code in `gha-scala-library-release-workflow`:

https://github.com/guardian/gha-scala-library-release-workflow/blob/26b2cde0632c786fea6a4fc4b40c7a3cfbaa68bb/.github/workflows/reusable-release.yml#L87

...(in particular the `${GITHUB_REF_NAME//[^[:alnum:]-_]/}` part) has already done a bit of cleanup on the original branch name `update/non_aws` - making it into `updatenon_aws` with the slash (`/`) stripped out, but it's the remaining _underscore_ (`_`) that's causing the problem.

The regex `sbt-release` is using for version numbers, defined here:

https://github.com/sbt/sbt-release/blob/v1.4.0/src/main/scala/Version.scala#L58

...specifically the `([\.\-0-9a-zA-Z]*)` bit, doesn't like underscores in version numbers, so the `non_aws` part is no good, and we get the version format error.

Note that the current semver spec (2.0.0) has a [tight constraint](https://semver.org/#spec-item-9) on allowable characters in a version string:

> Identifiers MUST comprise only ASCII alphanumerics and hyphens [0-9A-Za-z-]"

...so `sbt-release` is correct here, we shouldn't allow underscores.

Consequently, this change ensures we strip underscores too - you can check this at the bash prompt like this:

```
$ GITHUB_REF_NAME="update/non_aws/roberto-tyley-is-da-coolest.so-true"
$ echo "-PREVIEW.${GITHUB_REF_NAME//[^[:alnum:]-]/}.$(date +%Y-%m-%dT%H%M)"
-PREVIEW.updatenonawsroberto-tyley-is-da-coolestso-true.2024-02-16T1503
```
