### PR TITLE
Fix Sonatype session name so it's not identical with each release

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -352,7 +352,7 @@ jobs:
 
   sonatype-release:
     name: 🔒 Sonatype Release
-    needs: sign
+    needs: [push-release-commit, sign]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/cache/restore@v4
@@ -366,11 +366,12 @@ jobs:
           sonatypeBundleDirectory := new File("$LOCAL_ARTIFACTS_STAGING_PATH")
           sonatypeProfileName := "${{ inputs.SONATYPE_PROFILE_NAME }}"
           sonatypeCredentialHost := "${{ inputs.SONATYPE_CREDENTIAL_HOST }}"
+          version := "${{ needs.push-release-commit.outputs.release_version }}"
           EndOfFile
           
           mkdir project
-          echo 'addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.21")' > project/plugins.sbt
-          echo 'sbt.version = 1.9.8' > project/build.properties
+          echo 'addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.10.0")' > project/plugins.sbt
+          echo 'sbt.version = 1.9.9' > project/build.properties
           
           ls -lR .
       - uses: actions/setup-java@v4


### PR DESCRIPTION
When you upload a release to Sonatype you say what you want the 'session' to be called - we want this to be unique to each version, because in principle you might want to set off two different preview releases at the same time, and you wouldn't want them fighting over the same Sonatype session (eg, a race condition where one release finishes, and closes the session, before the other release is finished).

However, the `🔒 Sonatype Release` job has been uploading with session names that have sbt's fixed _default_ version number ([`0.1.0-SNAPSHOT`](https://github.com/sbt/sbt/blob/48c23761dc5ffe191a79424ba830dafcd2ec7631/main/src/main/scala/sbt/Defaults.scala#L257)) embedded in them:

```
[sbt-sonatype] redirect-resolver 0.1.0-SNAPSHOT
```

This PR ensures that the `🔒 Sonatype Release` job passes the correct version number to the `sbt-sonatype` plugin, so it uses a properly unique session name. The name is also less confusing, as it's natural to wonder where on earth `0.1.0-SNAPSHOT` came from when looking at the release logs.


See also _"What about the weird '0.1.0-SNAPSHOT' in the logs?"_ in https://github.com/guardian/marley/pull/102#issuecomment-1862737442


## Before

https://github.com/guardian/redirect-resolver/actions/runs/8046085369/job/21972709388#step:5:26

> Creating a staging repository in profile com.gu with a description key: [sbt-sonatype] redirect-resolver 0.1.0-SNAPSHOT


## After

#### Full Main-Branch Release

https://github.com/guardian/redirect-resolver/actions/runs/8171734462/job/22340783352#step:5:29
> Creating a staging repository in profile com.gu with a description key: [sbt-sonatype] redirect-resolver 0.0.33

#### PR Preview Release

https://github.com/guardian/redirect-resolver/actions/runs/8171987018/job/22341483979#step:5:29

> Creating a staging repository in profile com.gu with a description key: [sbt-sonatype] redirect-resolver 0.0.34-PREVIEW.rtyley-patch-2.2024-03-06T1223.1ef19995
