### PR TITLE
Require projects specify Java version in `.tool-versions` so we build with that version, use Java 21 LTS elsewhere

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -10,6 +10,11 @@ on:
         default: '807361' # Only for use by the Guardian!
         required: false # ...but if you're not the Guardian, you'll want to set this explicitly
         type: string
+      LIBRARY_BUILD_JAVA_VERSION_FILE:
+        description: "Path within the repo to the java-version-file - see https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#java-version-file"
+        default: '.tool-versions' # as used by https://asdf-vm.com/
+        required: false
+        type: string
       SONATYPE_PROFILE_NAME:
         description: 'Sonatype account profile name, eg "com.gu", "org.xerial", etc (not your Sonatype username)'
         default: 'com.gu' # Only for use by the Guardian!
@@ -54,6 +59,7 @@ env:
   RUN_ATTEMPT_UID: ${{ github.run_id }}-${{ github.run_attempt }}
   TEMPORARY_BRANCH: release-workflow/temporary/${{ github.run_id }}
   GITHUB_REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+  LATEST_LTS_JAVA_VERSION: '21' # Used by all parts of the workflow that are not invoking the library's build process
 
 jobs:
   init:
@@ -68,7 +74,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: corretto
-          java-version: 17
+          java-version: ${{ env.LATEST_LTS_JAVA_VERSION }}
           gpg-private-key: ${{ secrets.PGP_PRIVATE_KEY }}
       - name: Read Identifiers from Signing Key
         id: read-identifiers
@@ -115,7 +121,7 @@ jobs:
       - uses: actions/setup-java@v4 # don't 'cache: sbt', at least until https://github.com/actions/setup-java/pull/564 is merged
         with:
           distribution: corretto
-          java-version: 17
+          java-version-file: ${{ inputs.LIBRARY_BUILD_JAVA_VERSION_FILE }}
 #      - name: Debug MIMA assessment
 #        run: |
 #          sbt "show versionPolicyFindIssues"
@@ -176,7 +182,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: corretto
-          java-version: 17
+          java-version: ${{ env.LATEST_LTS_JAVA_VERSION }}
           gpg-private-key: ${{ secrets.PGP_PRIVATE_KEY }}
       - name: Create commit
         id: create-commit
@@ -250,7 +256,7 @@ jobs:
       - uses: actions/setup-java@v4 # don't 'cache: sbt', at least until https://github.com/actions/setup-java/pull/564 is resolved
         with:
           distribution: corretto
-          java-version: 17
+          java-version-file: ${{ inputs.LIBRARY_BUILD_JAVA_VERSION_FILE }}
       - name: Generate artifacts
         run: |
           cat << EndOfFile > sbt-commands.txt
@@ -305,7 +311,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: corretto
-          java-version: 17
+          java-version: ${{ env.LATEST_LTS_JAVA_VERSION }}
           gpg-private-key: ${{ secrets.PGP_PRIVATE_KEY }}
       - name: Sign artifacts
         run: |
@@ -377,7 +383,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: corretto
-          java-version: 17
+          java-version: ${{ env.LATEST_LTS_JAVA_VERSION }}
           cache: sbt # the issue described in https://github.com/actions/setup-java/pull/564 doesn't affect this step (no version.sbt)
       - name: Release
         env:


### PR DESCRIPTION
Unfortunately this PR is is somewhat blocked, as `actions/setup-java` support for `.tool-versions` is somewhat broken:

* https://github.com/actions/setup-java/issues/615

Using our own parsing of the `.tool-versions` file may be a way around this, eg:

```
echo "java corretto-21.0.2.13.1" | grep -Eo 'java [[:alpha:]-]+-[[:digit:]]+' | rev | cut -d'-' -f1 | rev
21
```

## Respect `.tool-versions`!

Thanks to these PRs in the GitHub Action [`actions/setup-java`](https://github.com/actions/setup-java):

* https://github.com/actions/setup-java/pull/426
* https://github.com/actions/setup-java/pull/606

...we no longer need to additionally specify a Java version number in GitHub Workflow YAML (eg in [ci.yml](https://github.com/guardian/redirect-resolver/blob/905c3cfeee1770e6906fc05e8b82b92eeabe4b23/.github/workflows/ci.yml#L23) - instead, we can just tell `actions/setup-java` to read it from our [asdf](https://github.com/asdf-vm/asdf) `.tool-versions` file as a source of truth - one less place to update when we upgrade Java, and better documentation and UX for developers!

For the 2 places in our `gha-scala-library-release-workflow` where we run the library repo's build process (ie `🎊 Test & Version` & `🎊 Create artifacts`), its best that we use whatever version of Java they specify in their `.tool-versions` file - this means we're now actually _requiring_ them to have a `.tool-versions` file, which is not really a big imposition - better standardisation.

Note problems encountered in https://github.com/actions/setup-java/pull/606/files#r1524819663

## Java 21 LTS

John Duffell [reports in `P&E/DevX Stream` chat](https://chat.google.com/room/AAAAag0I08g/Nvinl3aN_cU/) and https://github.com/guardian/support-frontend/pull/5792 that Java 21 LTS delivers improved lambda-startup time over Java 11 (the performance improvements may have occurred in versions of Java between 11 and 21, not sure, but definitely seen in Java 21), and Mariot has confirmed that we should be encouraging people to move to Java 21.

`gha-scala-library-release-workflow` uses Java for several of its stages, and only 2 of those stages need to use _the version of Java required by the library project_, so for the others, we just use the latest LTS version of Java - Java 21 LTS.

* https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html#jdk-21-compatibility-notes

## `-release:X` in sbt `scalacOptions`

We do recommend that repos specify the `-release` flag in their `build.sbt` `scalacOptions`, which specifies the minimum release of Java that should be supported in the resulting artifacts - without this flag, the built artifacts will only support the version of Java they were compiled with, or above - and we may well want to take advantage of compiling with a newer version of Java, even if we have to release artifacts compatible with older versions of Java for services that have not updated yet.

