### PR TITLE
Docs: Explain GitHub App needs access to each repo

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,6 +10,10 @@ The release workflow needs a `release.yml` GitHub workflow in your repo, and spe
 
 ## Repo settings
 
+* Ensure [your GitHub App](github-app.md) has access to your repo. **Guardian developers:** click
+  `Configure` on the [gu-scala-library-release](https://github.com/apps/gu-scala-library-release) app,
+  so long as you have admin permissions on your repo, you should be able to add your repo to the list
+  of select repositories the app has access to.
 * Disable [branch protection **rules**](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches)
   on any branch the workflow will be pushing to (ie the default branch). Note that
   PR https://github.com/guardian/gha-scala-library-release-workflow/pull/26 means that you _can_ use

--- a/docs/org-setup.md
+++ b/docs/org-setup.md
@@ -1,20 +1,11 @@
 # Organisation Setup
 
-These instructions are the initial setup for an organisation that's going to use `gha-scala-library-release-workflow`.
+These steps are the initial setup for an organisation that's going to use `gha-scala-library-release-workflow`.
 When we say "organisation", we mean a GitHub organisation (like [github.com/guardian](https://github.com/guardian)), but
-these instructions more or less also apply to a single GitHub user account, if you want to set up your own personal
-repos to use this workflow.
+these instructions also apply to a single GitHub user account, if you want to set up your own personal
+repos to use the workflow.
 
-## 1. Set up the GitHub App
-
-See [Setting up the GitHub App](github-app.md) for details on how to create the necessary GitHub App.
-
-## 2. Create credentials
-
-See [Generating new credentials](credentials/generating-credentials.md) for details on how to create the necessary
-credentials, and [Supplying credentials](credentials/supplying-credentials.md) for how to store and supply them to
-your repos.
-
-## 3. Configure repos to use the release workflow
-
-See [Configuration](configuration.md) for details on how to configure your repos to use the release workflow.
+1. [Create the GitHub App](github-app.md) to perform actions on your repos, like pushing commits and making PR comments.
+2. [Generate release credentials](credentials/generating-credentials.md) (ie Sonatype account, PGP key, etc) and
+   get ready to [supply them to the workflow](credentials/supplying-credentials.md).
+3. [Configure your repos](configuration.md) to use the release workflow.


### PR DESCRIPTION
Following on from https://github.com/guardian/gha-scala-library-release-workflow/pull/26, which introduced the need to have a GitHub App, this updates the docs further to explain that the GitHub App must be granted access to each repo that it acts upon.

If the GitHub App does not have access to the repo, the release flow will [fail](https://github.com/guardian/content-entity/actions/runs/8347150774):

> Maven Release / 🔒 Push Release Commit
> Not Found - https://docs.github.com/rest/apps/apps#get-a-repository-installation-for-the-authenticated-app

![image](https://github.com/guardian/gha-scala-library-release-workflow/assets/52038/29cfb577-e9a4-464e-ad49-bb91dc339626)
