### PR TITLE
Allow users to commit to the `main` branch while full release running

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -301,7 +301,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       KEY_FINGERPRINT: ${{ needs.init.outputs.key_fingerprint }}
-      ARTIFACT_SHA256SUMS: ${{ needs.create-artifacts.outputs.ARTIFACT_SHA256SUMS }}
     steps:
       - id: generate-github-app-token
         uses: actions/create-github-app-token@v1
@@ -312,7 +311,7 @@ jobs:
         with:
           path: repo
           ref: ${{ needs.push-release-commit.outputs.release_commit_id }}
-          fetch-depth: 2 # To fast-forward the main branch, we need the commit on main, as well as the release commit
+          fetch-depth: 1 # For tag-signing, we only need the release commit - branch operations done with GitHub API
           token: ${{ steps.generate-github-app-token.outputs.token }}
           persist-credentials: true # Allow us to push as the GitHub App, and bypass branch ruleset
       - uses: actions/cache/restore@v4
@@ -321,6 +320,8 @@ jobs:
           key: unsigned-${{ env.RUN_ATTEMPT_UID }}
           fail-on-cache-miss: true
       - name: Verify artifact hashes before signing
+        env:
+          ARTIFACT_SHA256SUMS: ${{ needs.create-artifacts.outputs.ARTIFACT_SHA256SUMS }}
         run: |
           sudo apt-get install hashdeep -q > /dev/null
           ARTIFACT_SHA256SUMS_FILE=$( mktemp )
@@ -342,24 +343,31 @@ jobs:
         run: |
           echo "KEY_FINGERPRINT=$KEY_FINGERPRINT"
           find $LOCAL_ARTIFACTS_STAGING_PATH -type f -exec gpg -a --local-user "$KEY_FINGERPRINT" --detach-sign {} \;
+      - name: "Full Main-Branch release: Add release commit (from temporary release branch) to default branch"
+        if: needs.init.outputs.release_type == 'FULL_MAIN_BRANCH'
+        env:
+          GH_TOKEN: ${{ steps.generate-github-app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_COMMIT_ID: ${{ needs.push-release-commit.outputs.release_commit_id }}
+        run: |
+          if gh api --silent --method PATCH /repos/:owner/:repo/git/refs/heads/$GITHUB_REF_NAME -f "sha=$RELEASE_COMMIT_ID"; then
+            echo "...fast-forward of default branch to include release commit succeeded"
+          else
+            echo "...fast-forward failed (commits added to default branch while release running?), will attempt a merge instead"
+            gh api --silent --method POST /repos/:owner/:repo/merges -f "base=$GITHUB_REF_NAME" -f "head=$RELEASE_COMMIT_ID"
+          fi
       - name: Push signed tag
         env:
           RELEASE_TAG: ${{ needs.push-release-commit.outputs.release_tag }}
           RELEASE_COMMIT_ID: ${{ needs.push-release-commit.outputs.release_commit_id }}
           KEY_EMAIL: ${{ needs.init.outputs.key_email }}
+          ARTIFACT_SHA256SUMS: ${{ needs.create-artifacts.outputs.ARTIFACT_SHA256SUMS }}
         run: |
           cd $GITHUB_WORKSPACE/repo
           git config user.email "$KEY_EMAIL"
           git config user.name "$COMMITTER_NAME"
           git config tag.gpgSign true
           git config user.signingkey "$KEY_FINGERPRINT"
-          
-          if [ "${{ needs.init.outputs.release_type }}" == "FULL_MAIN_BRANCH" ]
-          then
-            echo "Full Main-Branch release, fast-forwarding the default branch to the release commit"
-            git log --oneline -n 3
-            git push origin $RELEASE_COMMIT_ID:refs/heads/$GITHUB_REF_NAME
-          fi
           
           cat << EndOfFile > tag-message.txt
           Release $RELEASE_TAG initiated by $COMMITTER_NAME


### PR DESCRIPTION
This should fix #37 - ie, a Full Main-Branch release should still succeed, even if someone adds additional commits to the `main` branch while the release workflow is running. 

Note that this change in behaviour only applies to Full Main-Branch releases, not [Preview releases](https://github.com/guardian/gha-scala-library-release-workflow/pull/19), as Preview releases don't ever attempt to update any branch.

## Avoid making a merge commit if possible

To avoid the noise of an additional merge commit (ie a 3rd commit) we prefer a fast-forward, and only create a merge commit if it's _necessary_ - that's when someone has done additional commits on the `main` branch.

These diagrams show how the resulting `git` history will look after a release:

### A release where no extra work was done on `main` branch (fast-forward possible)

```mermaid
---
config:
  gitGraph:
    parallelCommits: true
    showCommitLabel: true
---
gitGraph
   commit id: "commit before release"
   commit id: "release commit" tag: "v1.0.0"
   commit id: "set snapshot"
```

### A release where extra work added to `main` branch during release (requires a merge)

```mermaid
---
config:
  gitGraph:
    parallelCommits: true
    showCommitLabel: true
---
gitGraph
   commit id: "commit before release"
   branch release-workflow/temporary/xxx
   checkout release-workflow/temporary/xxx
   commit id: "release commit" tag: "v1.0.0"
   checkout main
   commit id: "extra work" type: HIGHLIGHT
   merge release-workflow/temporary/xxx
   commit id: "set snapshot"
```

## Two full Main-Branch releases can't run concurrently

Although we can now handle extra work on the `main` branch, running **two releases at once** is _not_ recommended!

## Using the GitHub API to create & merge commits, rather than `git` 

We're now using the GitHub API, rather than `git`, to do both these operations:

* [Update the branch](https://docs.github.com/en/rest/git/refs?apiVersion=2022-11-28#update-a-reference) to try fast-forwarding - using the GitHub API means we don't need to clone a deep history of the repo to make that update
* [Merge the branch](https://docs.github.com/en/rest/branches/branches?apiVersion=2022-11-28#merge-a-branch) if the fast-forward fails - using the GitHub API means that the merge commit will be signed/verified by GitHub too, [just like other commits created by the GitHub App](https://github.com/guardian/gha-scala-library-release-workflow/pull/26).

## Testing

Here are two successful full-main-branch release runs [using this branch](https://github.com/guardian/etag-caching/commit/bb669b8c9a4fc799d30938c7317f3b3765412876): 

* [No extra commits](https://github.com/guardian/etag-caching/actions/runs/9660182538/job/26645336020) ![image](https://github.com/guardian/gha-scala-library-release-workflow/assets/52038/7281a1be-0e1a-409e-96b1-02f8cb965812) ```...fast-forward of default branch to include release commit succeeded``` ![image](https://github.com/guardian/gha-scala-library-release-workflow/assets/52038/c0fb7292-e6d1-4c6a-9a23-b8aa8e896a8d)
* [Extra commits during release](https://github.com/guardian/etag-caching/actions/runs/9666072585/job/26664876203) ![image](https://github.com/guardian/gha-scala-library-release-workflow/assets/52038/828a1de8-69a1-4400-bab2-6df4148b1781)
  ```
  gh: Update is not a fast forward (HTTP 422)
  ...fast-forward failed (commits added to default branch while release running?), will attempt a merge instead
  ```
  ![image](https://github.com/guardian/gha-scala-library-release-workflow/assets/52038/9bcd63f8-5adc-4409-a2b4-52c18dd38e12)
