### PR TITLE
Fix link to create GitHub App: use `pull_requests` with underscore

### DIFF
--- a/docs/github-app.md
+++ b/docs/github-app.md
@@ -17,7 +17,7 @@ so that we don't share private keys.
 You can just click this link to get taken to a pre-filled page to create a new GitHub App - you'll just need to
 customise the app name:
 
-https://github.com/settings/apps/new?name=scala-library-release&url=https://github.com/guardian/gha-scala-library-release-workflow&public=false&contents=write&pull-requests=write&webhook_active=false
+https://github.com/settings/apps/new?name=scala-library-release&url=https://github.com/guardian/gha-scala-library-release-workflow&public=false&contents=write&pull_requests=write&webhook_active=false
 
 ### GitHub App for an organisation account
 


### PR DESCRIPTION
This fixes a small documentation mistake I made in https://github.com/guardian/gha-scala-library-release-workflow/pull/26, where usage of a Github App was introduced.

I supplied a link in the docs to help create a new GitHub App, this link was supposed to pre-populate the form with the 3 necessary permissions (Contents: Read and write, Pull Requests: Read and write, and Metadata: Read-only). However, checking it now, it only provided 2 of 3, and the 'Pull Requests' permission wasn't set:

![image](https://github.com/guardian/gha-scala-library-release-workflow/assets/52038/16951018-05d3-48a1-bc0e-5809c60d6664)

It turned out that I should have been using [`pull_requests=write`](https://github.com/settings/apps/new?name=scala-library-release&url=https://github.com/guardian/gha-scala-library-release-workflow&public=false&contents=write&pull_requests=write&webhook_active=false) in the url, rather than `pull-requests=write`.

![image](https://github.com/guardian/gha-scala-library-release-workflow/assets/52038/b968dbc6-9afa-444e-a3a3-3b3136869943)

This isn't documented, so far as I can see:

https://docs.github.com/en/apps/sharing-github-apps/registering-a-github-app-using-url-parameters

...but in the end I managed to guess it!
