### PR TITLE
Use updated `sbt-sonatype`(that has support for Sonatype's Central Portal API)

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -16,7 +16,7 @@ on:
         required: false # Must be supplied if used by a non-Guardian project
         type: string
       SONATYPE_CREDENTIAL_HOST:
-        description: 'The host of your SONATYPE_PROFILE_NAME, either "oss.sonatype.org" or "s01.oss.sonatype.org"'
+        description: 'The host of your SONATYPE_PROFILE_NAME: either "central.sonatype.com" or one of the legacy "oss.sonatype.org"/"s01.oss.sonatype.org" hosts'
         default: 'oss.sonatype.org' # The default host is going to be whatever "com.gu" is using
         required: false # ...but if you're not the Guardian, you'll want to set this explicitly
         type: string
@@ -410,7 +410,7 @@ jobs:
           EndOfFile
           
           mkdir project
-          echo 'addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.10.0")' > project/plugins.sbt
+          echo 'addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.12.2")' > project/plugins.sbt
           echo 'sbt.version = 1.9.9' > project/build.properties
           
           ls -lR .


### PR DESCRIPTION
As described in https://github.com/guardian/gha-scala-library-release-workflow/issues/57, Sonatype have [announced](https://central.sonatype.org/news/20250326_ossrh_sunset/) the End-of-Life Sunset Date for OSSRH: 30th June 2025. All organisations will need to migrate to the [Central Publisher Portal](https://central.sonatype.org/publish/publish-portal-guide/).

There are a few steps that we need to undertake to make this work, but very few changes to the code of [`gha-scala-library-release-workflow`](https://github.com/guardian/gha-scala-library-release-workflow) itself are required:

* **This PR** : Upgrading to the latest version of the `sbt-sonatype` plugin, which includes https://github.com/xerial/sbt-sonatype/pull/474 for support of the new Sonatype Central API (note that while this _works_, there have been issues with [timeouts](https://github.com/lumidion/sonatype-central-client/pull/22)). Doing this upgrade means [external users](https://github.com/guardian/gha-scala-library-release-workflow/issues/57#issuecomment-2866255653) who have already migrated their namespace can use `gha-scala-library-release-workflow` for performing their releases to the Central Publisher Portal.
* **Later, once we've migrated `com.gu` to Central** - we'll change the default value of `SONATYPE_CREDENTIAL_HOST` to `central.sonatype.com` - the older `oss.sonatype.org` systems will be shutdown soon anyway https://github.com/guardian/gha-scala-library-release-workflow/blob/abe60aa341cf39aade6a03208f394fbc41189633/.github/workflows/reusable-release.yml#L20

## Testing

We've used this PR on Roberto's personal `com.madgag` namespace to check that publishing is still possible with this update:

* https://github.com/rtyley/scala-collection-plus/pull/2