### PR TITLE
Use PR url as `info.releaseNotesUrl` for preview releases

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -172,6 +172,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       release_tag: ${{ steps.create-commit.outputs.release_tag }}
+      release_notes_url: ${{ steps.create-commit.outputs.release_notes_url }}
       release_version: ${{ steps.create-commit.outputs.release_version }}
       release_commit_id: ${{ steps.create-commit.outputs.release_commit_id }}
       version_file_path: ${{ steps.create-commit.outputs.version_file_path }}
@@ -216,6 +217,14 @@ jobs:
           git fetch unsigned
           
           RELEASE_VERSION=${RELEASE_TAG#"v"}
+          
+          if [[ "${{ needs.init.outputs.release_type }}" = "FULL_MAIN_BRANCH" ]]; then
+            RELEASE_NOTES_URL=$GITHUB_REPO_URL/releases/tag/$RELEASE_TAG
+          else
+            # Use the PR url as the release notes url when doing a 'preview' release
+            RELEASE_NOTES_URL=$( gh pr view $GITHUB_REF_NAME --json url -q .url )
+          fi
+          
           VERSION_FILE_PATH=$(git diff-tree --no-commit-id --name-only -r $RELEASE_TAG | grep version.sbt)
           VERSION_FILE_INITIAL_SHA=$( git rev-parse $GITHUB_REF:$VERSION_FILE_PATH )
           VERSION_FILE_RELEASE_SHA=$( git rev-parse $RELEASE_TAG:$VERSION_FILE_PATH )
@@ -233,7 +242,7 @@ jobs:
           Release-Version: $RELEASE_VERSION
           Release-Initiated-By: ${{ github.server_url }}/${{github.actor}}
           Release-Workflow-Run: $GITHUB_REPO_URL/actions/runs/${{ github.run_id }}
-          GitHub-Release-Notes: $GITHUB_REPO_URL/releases/tag/$RELEASE_TAG
+          Release-Notes: $RELEASE_NOTES_URL
           EndOfFile
 
           # Create temporary branch to push the release commit- required for PREVIEW releases
@@ -247,6 +256,7 @@ jobs:
                     
           cat << EndOfFile >> $GITHUB_OUTPUT
           release_tag=$RELEASE_TAG
+          release_notes_url=$RELEASE_NOTES_URL
           release_version=$RELEASE_VERSION
           release_commit_id=$release_commit_id
           version_file_path=$VERSION_FILE_PATH
@@ -275,6 +285,7 @@ jobs:
           cat << EndOfFile > sbt-commands.txt
           set every sonatypeProjectHosting := Some(xerial.sbt.Sonatype.GitHubHosting("$GITHUB_REPOSITORY_OWNER", "${GITHUB_REPOSITORY#*/}", "${{ needs.init.outputs.key_email }}"))
           set ThisBuild / publishTo := Some(Resolver.file("foobar", file("$LOCAL_ARTIFACTS_STAGING_PATH")))
+          set ThisBuild / releaseNotesURL := Some(url("${{ needs.push-release-commit.outputs.release_notes_url }}"))
           EndOfFile
           cat sbt-commands.txt
           
@@ -438,6 +449,7 @@ jobs:
     env:
       RELEASE_TAG: ${{ needs.push-release-commit.outputs.release_tag }}
       RELEASE_VERSION: ${{ needs.push-release-commit.outputs.release_version }}
+      RELEASE_NOTES_URL: ${{ needs.push-release-commit.outputs.release_notes_url }}
       GH_REPO: ${{ github.repository }}
     steps:
       - id: generate-github-app-token
@@ -467,12 +479,12 @@ jobs:
           GH_TOKEN: ${{ steps.generate-github-app-token.outputs.token }}
         run: |
           gh release create $RELEASE_TAG --verify-tag --generate-notes --notes "Release run: $GITHUB_WORKFLOW_RUN_LINK"
-          echo "GitHub Release notes: [$RELEASE_TAG]($GITHUB_REPO_URL/releases/tag/$RELEASE_TAG)" >> $GITHUB_STEP_SUMMARY
+          echo "GitHub Release notes: [$RELEASE_TAG]($RELEASE_NOTES_URL)" >> $GITHUB_STEP_SUMMARY
           
           cat << EndOfFile > commit-message.txt
           Post-release of $RELEASE_TAG by @${{github.actor}}: set snapshot version
           
-          Setting snapshot version after @${{github.actor}} published $GITHUB_REPO_URL/releases/tag/$RELEASE_TAG
+          Setting snapshot version after @${{github.actor}} published $RELEASE_NOTES_URL
           EndOfFile
           
           gh api --method PUT /repos/:owner/:repo/contents/${{ needs.push-release-commit.outputs.version_file_path }} \

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -69,6 +69,8 @@ library.
 
 ## `sbt`
 
+Minimum `sbt` version: [**1.9.0**](https://github.com/sbt/sbt/releases/tag/v1.9.0)
+
 ### Recommended `sbt` plugins
 
 [Example `project/plugins.sbt`](https://github.com/guardian/etag-caching/blob/main/project/plugins.sbt)


### PR DESCRIPTION
This change is prompted by:

* https://github.com/guardian/scala-steward-public-repos/pull/90 - a new feature allowing us to **auto-raise draft PRs** trying out new (preview) releases

...we wanted the descriptions for those PRs to link _back_ to the PR creating the preview release, but Scala Steward gives us only limited control over the PR description. We _did_ identify that Scala Steward will link to 'custom release notes', the url of which it derives from a new-ish `info.releaseNotesUrl` field you can include in the `.pom` xml file when you publish the artifact. `sbt` supports this with the `releaseNotesURL` setting added in `sbt` [v1.9](https://github.com/sbt/sbt/releases/tag/v1.9.0).


![image](https://github.com/user-attachments/assets/61035cce-9753-4b1b-92f2-f50e982d5bb5)

* `🔒 Push Release Commit` now reads whether the release is a full release or not (ie the `release_type`), and outputs a new `release_notes_url` value which will be the PR if this is a preview release
* `🎊 Create artifacts` will now set `releaseNotesURL` to that `release_notes_url` value, ensuring that the `.pom` files contain that metadata
* `🔒 Update GitHub` also re-uses the `release_notes_url` value, rather than constructing the url itself as it was previously doing.

### Testing

See the [`.pom`](https://repo1.maven.org/maven2/com/gu/etag-caching/core_3/8.1.3-PREVIEW.try-release-workflow-with-pr-60-adding-preview-release-notes-urls.2025-05-28T1642.fa7f6c7c/core_3-8.1.3-PREVIEW.try-release-workflow-with-pr-60-adding-preview-release-notes-urls.2025-05-28T1642.fa7f6c7c.pom) for [this preview release](https://github.com/guardian/etag-caching/pull/86#issuecomment-2916991250) :



![image](https://github.com/user-attachments/assets/f1b7048e-15fb-4100-893b-4443ff15d2de)

This has successfully included the `info.releaseNotesUrl` property:

```xml
<properties>
  <info.releaseNotesUrl>https://github.com/guardian/etag-caching/pull/86</info.releaseNotesUrl>
  <info.versionScheme>early-semver</info.versionScheme>
</properties>
```


### See also

* https://contributors.scala-lang.org/t/add-release-notes-urls-to-your-poms/6059
* https://github.com/sbt/sbt/pull/7148