### PR TITLE
Use `sbt`'s new built-in support for publishing to Central Portal

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -10,16 +10,6 @@ on:
         default: '807361' # Only for use by the Guardian!
         required: false # ...but if you're not the Guardian, you'll want to set this explicitly
         type: string
-      SONATYPE_PROFILE_NAME:
-        description: 'Sonatype account profile name, eg "com.gu", "org.xerial", etc (not your Sonatype username)'
-        default: 'com.gu' # Only for use by the Guardian!
-        required: false # Must be supplied if used by a non-Guardian project
-        type: string
-      SONATYPE_CREDENTIAL_HOST:
-        description: 'The host of your SONATYPE_PROFILE_NAME: either "central.sonatype.com" or one of the legacy "oss.sonatype.org"/"s01.oss.sonatype.org" hosts'
-        default: 'oss.sonatype.org' # The default host is going to be whatever "com.gu" is using
-        required: false # ...but if you're not the Guardian, you'll want to set this explicitly
-        type: string
     secrets:
       SONATYPE_TOKEN:
         description: 'Sonatype authentication token, colon-separated (username:password) - https://central.sonatype.org/publish/generate-token/'
@@ -414,32 +404,29 @@ jobs:
           key: signed-${{ env.RUN_ATTEMPT_UID }}
           fail-on-cache-miss: true
       - name: Create tiny sbt project to perform Sonatype upload
+        env:
+          SONATYPE_TOKEN: ${{ secrets.SONATYPE_TOKEN }}
         run: |
           cat << EndOfFile > build.sbt
-          sonatypeBundleDirectory := new File("$LOCAL_ARTIFACTS_STAGING_PATH")
-          sonatypeProfileName := "${{ inputs.SONATYPE_PROFILE_NAME }}"
-          sonatypeCredentialHost := "${{ inputs.SONATYPE_CREDENTIAL_HOST }}"
+          Global / stagingDirectory := new File("$LOCAL_ARTIFACTS_STAGING_PATH")
           version := "${{ needs.push-release-commit.outputs.release_version }}"
+          sonaDeploymentName := "${{ github.repository }} $GITHUB_REF_NAME ${{ needs.push-release-commit.outputs.release_version }} $RUN_ATTEMPT_UID"
+          credentials += Credentials("Sonatype Central Portal", "central.sonatype.com", userName = "${SONATYPE_TOKEN%%:*}", passwd = "${SONATYPE_TOKEN#*:}")
           EndOfFile
           
           mkdir project
-          echo 'addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.12.2")' > project/plugins.sbt
-          echo 'sbt.version = 1.9.9' > project/build.properties
+          echo 'sbt.version = 1.11.0' > project/build.properties
           
           ls -lR .
       - uses: actions/setup-java@v4
         with:
           distribution: corretto
-          java-version: 17
+          java-version: 21
           cache: sbt # the issue described in https://github.com/actions/setup-java/pull/564 doesn't affect this step (no version.sbt)
       - uses: sbt/setup-sbt@v1.1.8
       - name: Release
-        env:
-          SONATYPE_TOKEN: ${{ secrets.SONATYPE_TOKEN }}
         run: |
-          export SONATYPE_USERNAME="${SONATYPE_TOKEN%%:*}" # See https://github.com/xerial/sbt-sonatype/pull/62
-          export SONATYPE_PASSWORD="${SONATYPE_TOKEN#*:}"
-          sbt "sonatypeBundleRelease"
+          sbt "sonaRelease"
 
   github-release:
     name: 🔒 Update GitHub


### PR DESCRIPTION
_Merged only after we'd completed the [migration](https://github.com/guardian/gha-scala-library-release-workflow/issues/57) to Central Portal from OSSRH, and got all projects to use `v1` rather than `main` branch_

We addressed issue https://github.com/guardian/gha-scala-library-release-workflow/issues/57 (Sonatype sunsetting the OSSRH service, used for publishing artifacts into Maven Central) with PR https://github.com/guardian/gha-scala-library-release-workflow/pull/58, where we upgraded our version of [`sbt-sonatype`](https://github.com/xerial/sbt-sonatype) to use the plugin's new functionality for releasing to the new Central Portal Publishing API, based upon the new [`sonatype-central-client`](https://github.com/lumidion/sonatype-central-client) library.

Since then, support for the Central Portal Publishing API has been added to `sbt` **itself**, with https://github.com/sbt/sbt/pull/8126 released a few days ago in `sbt` [**v1.11.0**](https://github.com/sbt/sbt/releases/tag/v1.11.0). The implementation in `sbt` was inspired by the work in `sbt-sonatype` & the `sonatype-central-client` library, but does not use either of them - and so could be seen as obsoleting a large part of `sbt-sonatype`. Overall, it seems better to switch `gha-scala-library-release-workflow` to use `sbt`'s built-in support.

Along with PR https://github.com/guardian/gha-scala-library-release-workflow/pull/62, this means that we've removed our dependency on `sbt-sonatype`, both in consuming projects, and in `gha-scala-library-release-workflow` itself.

Note that the requirement for sbt **1.11.0** is only within `gha-scala-library-release-workflow` itself - consuming projects are still fine to use sbt 1.9 or above:

https://github.com/guardian/gha-scala-library-release-workflow/blob/c07e7f60db0d357db72a4e759eb754a28d1a3897/docs/configuration.md?plain=1#L72

### Obsoleting workflow inputs `SONATYPE_PROFILE_NAME` & `SONATYPE_CREDENTIAL_HOST`

The new Central Publishing API doesn't use these settings, so we're getting rid of them - note that this will _break_ for users of `gha-scala-library-release-workflow` who have specified those values until they get round to removing the settings - so unfortunately it makes sense for this change to be released as `v2` of `gha-scala-library-release-workflow`.

### Testing

* https://github.com/rtyley/scala-collection-plus/pull/2 [ran successfully](https://github.com/rtyley/scala-collection-plus/actions/runs/15348372168) using this branch at commit 52039a72f