### PR TITLE
Switch to using `central.sonatype.com` by default

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -17,7 +17,7 @@ on:
         type: string
       SONATYPE_CREDENTIAL_HOST:
         description: 'The host of your SONATYPE_PROFILE_NAME: either "central.sonatype.com" or one of the legacy "oss.sonatype.org"/"s01.oss.sonatype.org" hosts'
-        default: 'oss.sonatype.org' # The default host is going to be whatever "com.gu" is using
+        default: 'central.sonatype.com' # The default host is going to be whatever "com.gu" is using
         required: false # ...but if you're not the Guardian, you'll want to set this explicitly
         type: string
     secrets:


### PR DESCRIPTION
See

* https://github.com/guardian/gha-scala-library-release-workflow/issues/57
