### PR TITLE
Remove lint warning on `sonaDeploymentName`

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -415,7 +415,7 @@ jobs:
           EndOfFile
           
           mkdir project
-          echo 'sbt.version = 1.11.0' > project/build.properties
+          echo 'sbt.version = 1.11.1' > project/build.properties
           
           ls -lR .
       - uses: actions/setup-java@v4


### PR DESCRIPTION
`sbt` [v1.11.1](https://github.com/sbt/sbt/releases/tag/v1.11.1) includes https://github.com/sbt/sbt/pull/8143, which removes this incorrect lint warning during our release process:

```
[warn] there's a key that's not used by any other settings/tasks:
[warn]
[warn] * scala-collection-plus / sonaDeploymentName
[warn]   +- /home/runner/work/scala-collection-plus/scala-collection-plus/build.sbt:3
[warn]
[warn] note: a setting might still be used by a command; to exclude a key from this `lintUnused` check
[warn] either append it to `Global / excludeLintKeys` or call .withRank(KeyRanks.Invisible) on the key
```
