### PR TITLE
Break workflow up: a reusable workflow using reusable actions

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -28,487 +28,125 @@ on:
     outputs:
       RELEASE_VERSION:
         description: "The un-prefixed version number of the release, eg '3.0.1'"
-        value: ${{ jobs.push-release-commit.outputs.release_version }}
+        value: ${{ jobs.push-release-commit.outputs.release-version }}
       RELEASE_TYPE:
         description: "Either 'FULL_MAIN_BRANCH' or 'PREVIEW_FEATURE_BRANCH' - whether this is a full release or a pre-release"
-        value: ${{ jobs.init.outputs.release_type }}
-
-env:
-  LOCAL_ARTIFACTS_STAGING_PATH: /tmp/artifact_staging
-  COMMITTER_NAME: "@${{github.actor}} using gha-scala-library-release-workflow"
-  RUN_ATTEMPT_UID: ${{ github.run_id }}-${{ github.run_attempt }}
-  TEMPORARY_BRANCH: release-workflow/temporary/${{ github.run_id }}
-  GITHUB_REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+        value: ${{ jobs.init.outputs.release-type }}
 
 jobs:
   init:
     name: 🔒 Init
     runs-on: ubuntu-latest
     outputs:
-      key_fingerprint: ${{ steps.read-identifiers.outputs.key_fingerprint }}
-      key_email: ${{ steps.read-identifiers.outputs.key_email }}
-      release_type: ${{ steps.generate-version-suffix.outputs.release_type }}
-      version_suffix: ${{ steps.generate-version-suffix.outputs.version_suffix }}
+      pgp-key-fingerprint: ${{ steps.act.outputs.pgp-key-fingerprint }}
+      pgp-key-email: ${{ steps.act.outputs.pgp-key-email }}
+      release-type: ${{ steps.act.outputs.release-type }}
+      version-suffix: ${{ steps.act.outputs.version-suffix }}
     steps:
-      - uses: actions/setup-java@v4
+      - id: act
+        uses: guardian/gha-scala-library-release-workflow/actions/init@break-workflow-up-into-smaller-reusable-files
         with:
-          distribution: corretto
-          java-version: 17
-          gpg-private-key: ${{ secrets.PGP_PRIVATE_KEY }}
-      - name: Read Identifiers from Signing Key
-        id: read-identifiers
-        run: |
-          key_fingerprint_and_email=$(gpg2 --list-secret-keys --list-options show-only-fpr-mbox)
-          key_fingerprint=$(echo $key_fingerprint_and_email | awk '{print $1}')
-          key_email=$(echo $key_fingerprint_and_email | awk '{print $2}')
-          echo "key_fingerprint=$key_fingerprint"
-          
-          cat << EndOfFile >> $GITHUB_OUTPUT
-          key_fingerprint=$key_fingerprint
-          key_email=$key_email
-          EndOfFile
-          if ! [[ "$key_fingerprint" =~ ^[[:xdigit:]]{8,}$ ]]; then
-            echo "::error title=Missing PGP key::Has PGP_PRIVATE_KEY been set correctly? https://github.com/guardian/gha-scala-library-release-workflow/blob/main/docs/credentials/supplying-credentials.md"
-            exit 1
-          fi
-      - name: Check for default branch
-        id: generate-version-suffix
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          default_branch=$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name ${{ github.repository }})
-   
-          if [[ "$default_branch" = $GITHUB_REF_NAME ]]; then
-            release_type="FULL_MAIN_BRANCH"
-            version_suffix=""
-          else
-            release_type="PREVIEW_FEATURE_BRANCH"
-            version_suffix="-PREVIEW.${GITHUB_REF_NAME//[^[:alnum:]-]/}.$(date +%Y-%m-%dT%H%M).${GITHUB_SHA:0:8}"
-          fi
-          echo "current branch: $GITHUB_REF_NAME, release_type: $release_type, version_suffix: $version_suffix"
-          cat << EndOfFile >> $GITHUB_OUTPUT
-          release_type=$release_type
-          version_suffix=$version_suffix
-          EndOfFile
+          pgp-private-key: ${{ secrets.PGP_PRIVATE_KEY }}
 
-  generate-version-update-commits:
-    name: 🎊 Test & Version
+  versioning:
+    name: 🎊 Versioning
     needs: init
     runs-on: ubuntu-latest
     outputs:
-      library_build_major_java_version: ${{ steps.establish_java_for_library_build.outputs.library_build_major_java_version }}
+      library-build-major-java-version: ${{ steps.act.outputs.library-build-major-java-version }}
     steps:
-      - uses: actions/checkout@v4
-      - id: establish_java_for_library_build
-        name: Establish library build Java version
-        run: |
-          if [ ! -f .tool-versions ]; then
-            echo "::error title=Missing .tool-versions file::gha-scala-library-release-workflow requires an asdf-format .tool-versions file to establish the Java version for the build."
-            exit 1
-          fi
-          LIBRARY_BUILD_MAJOR_JAVA_VERSION=$( grep -Eo 'java [[:alnum:]-]+-[[:digit:]]+' .tool-versions | rev | cut -d'-' -f1 | rev )
-          echo "Using Java $LIBRARY_BUILD_MAJOR_JAVA_VERSION"
-          if [ -z "${LIBRARY_BUILD_MAJOR_JAVA_VERSION}" ]; then
-            echo "::error title=Missing Java version in .tool-versions file::Could not establish the library's required Java version - the '.tool-versions' file should have a line like 'java corretto-21.0.3.9.1'."
-            exit 1
-          fi
-          
-          cat << EndOfFile >> $GITHUB_OUTPUT
-          library_build_major_java_version=$LIBRARY_BUILD_MAJOR_JAVA_VERSION
-          EndOfFile
-      - uses: actions/setup-java@v4 # don't 'cache: sbt', at least until https://github.com/actions/setup-java/pull/564 is merged
+      - id: act
+        uses: guardian/gha-scala-library-release-workflow/actions/versioning@break-workflow-up-into-smaller-reusable-files
         with:
-          distribution: corretto
-          java-version: ${{ steps.establish_java_for_library_build.outputs.library_build_major_java_version }}
-      - uses: sbt/setup-sbt@v1.1.9
-#      - name: Debug MIMA assessment
-#        run: |
-#          sbt "show versionPolicyFindIssues"
-      - name: Use sbt-release to construct version.sbt updates
-        run: |
-          git config user.email "${{ needs.init.outputs.key_email }}"
-          git config user.name "$COMMITTER_NAME"
-          
-          sbt_commands_file=$(mktemp)
-          cat << EndOfFile > $sbt_commands_file
-          set releaseVersion := releaseVersion.value.andThen(_ + "${{ needs.init.outputs.version_suffix }}")
-          release with-defaults
-          EndOfFile
-          cat $sbt_commands_file
-          sbt ";< $sbt_commands_file"
-          
-          echo $GITHUB_WORKSPACE
-          cd `mktemp -d`
-          git clone --bare $GITHUB_WORKSPACE repo-with-unsigned-version-update-commits.git
-          rm -Rf $GITHUB_WORKSPACE/*
-          mv repo-with-unsigned-version-update-commits.git $GITHUB_WORKSPACE/
-          ls -lR $GITHUB_WORKSPACE
-      - name: Job summary
-        run: |
-          cat << EndOfFile >> $GITHUB_STEP_SUMMARY
-          # Release $(git describe --tags --abbrev=0)
-          Library built with Java ${{ steps.establish_java_for_library_build.outputs.library_build_major_java_version }}.
-          EndOfFile
-      - uses: actions/cache/save@v4
-        with:
-          path: repo-with-unsigned-version-update-commits.git
-          key: repo-with-unsigned-version-update-commits-${{ env.RUN_ATTEMPT_UID }}
+          version-suffix: ${{ needs.init.outputs.version-suffix }}
 
   push-release-commit:
     name: 🔒 Push Release Commit
-    needs: [generate-version-update-commits, init]
+    # This job may become unusual for this workflow, in that it could be separated into several trusted action calls:
+    # * 'extract versioning metadata', a **platform-specific** (sbt/gradle) step which:
+    #   - verifies that only *approved* files (eg version.sbt) have been modified, and ideally constrains the modifications
+    #   - parses and outputs the version number
+    # * 'push verified release commit' - a generic action which pushes the verified content of the release commit to
+    #   GitHub, using the GitHub API, which means the release commit is authored & signed by our GitHub App
+    needs: [versioning, init]
     permissions:
       contents: write
     runs-on: ubuntu-latest
     outputs:
-      release_tag: ${{ steps.create-commit.outputs.release_tag }}
-      release_notes_url: ${{ steps.create-commit.outputs.release_notes_url }}
-      release_version: ${{ steps.create-commit.outputs.release_version }}
-      release_commit_id: ${{ steps.create-commit.outputs.release_commit_id }}
-      version_file_path: ${{ steps.create-commit.outputs.version_file_path }}
-      version_file_release_sha: ${{ steps.create-commit.outputs.version_file_release_sha }}
-      version_file_post_release_content: ${{ steps.create-commit.outputs.version_file_post_release_content }}
+      release-tag: ${{ steps.act.outputs.release-tag }}
+      release-notes-url: ${{ steps.act.outputs.release-notes-url }}
+      release-version: ${{ steps.act.outputs.release-version }}
+      release-commit-id: ${{ steps.act.outputs.release-commit-id }}
+      version-file-path: ${{ steps.act.outputs.version-file-path }}
+      version-file-release-sha: ${{ steps.act.outputs.version-file-release-sha }}
+      version-file-post-release-content: ${{ steps.act.outputs.version-file-post-release-content }}
+      temporary-branch: ${{ steps.act.outputs.temporary-branch }}
     steps:
-      - id: generate-github-app-token
-        uses: actions/create-github-app-token@v2
+      - id: act
+        uses: guardian/gha-scala-library-release-workflow/actions/push-release-commit@break-workflow-up-into-smaller-reusable-files
         with:
-          app-id: ${{ inputs.GITHUB_APP_ID }}
-          private-key: ${{ secrets.GITHUB_APP_PRIVATE_KEY }} }
-      - uses: actions/checkout@v4
-        with:
-          path: repo
-      - uses: actions/cache/restore@v4
-        with:
-          path: repo-with-unsigned-version-update-commits.git
-          key: repo-with-unsigned-version-update-commits-${{ env.RUN_ATTEMPT_UID }}
-          fail-on-cache-miss: true
-      - uses: actions/setup-java@v4
-        with:
-          distribution: corretto
-          java-version: 17
-          gpg-private-key: ${{ secrets.PGP_PRIVATE_KEY }}
-      - name: Create commit
-        id: create-commit
-        env:
-          KEY_FINGERPRINT: ${{ needs.init.outputs.key_fingerprint }}
-          KEY_EMAIL: ${{ needs.init.outputs.key_email }}
-          GH_TOKEN: ${{ steps.generate-github-app-token.outputs.token }}
-          GH_REPO: ${{ github.repository }}
-        run: |
-          echo "GITHUB_REF_NAME=$GITHUB_REF_NAME"
-          echo "GITHUB_REF=$GITHUB_REF"
-          
-          cd repo-with-unsigned-version-update-commits.git
-          RELEASE_TAG=$(git describe --tags --abbrev=0)
-          
-          cd ../repo
-          
-          git remote add unsigned ../repo-with-unsigned-version-update-commits.git
-          git fetch unsigned
-          
-          RELEASE_VERSION=${RELEASE_TAG#"v"}
-          
-          if [[ "${{ needs.init.outputs.release_type }}" = "FULL_MAIN_BRANCH" ]]; then
-            RELEASE_NOTES_URL=$GITHUB_REPO_URL/releases/tag/$RELEASE_TAG
-          else
-            # Use the PR url as the release notes url when doing a 'preview' release
-            RELEASE_NOTES_URL=$( gh pr view $GITHUB_REF_NAME --json url -q .url )
-          fi
-          
-          VERSION_FILE_PATH=$(git diff-tree --no-commit-id --name-only -r $RELEASE_TAG | grep version.sbt)
-          VERSION_FILE_INITIAL_SHA=$( git rev-parse $GITHUB_REF:$VERSION_FILE_PATH )
-          VERSION_FILE_RELEASE_SHA=$( git rev-parse $RELEASE_TAG:$VERSION_FILE_PATH )
-          VERSION_FILE_RELEASE_CONTENT=$( git cat-file blob $RELEASE_TAG:$VERSION_FILE_PATH | base64 -w0)
-          VERSION_FILE_POST_RELEASE_CONTENT=$( git cat-file blob unsigned/$GITHUB_REF_NAME:$VERSION_FILE_PATH | base64 -w0)
-
-          cd ..
-          
-          cat << EndOfFile > commit-message.txt
-          $RELEASE_TAG published by ${{github.actor}}
-          
-          ${{github.actor}} published release version $RELEASE_VERSION
-          using gha-scala-library-release-workflow: https://github.com/guardian/gha-scala-library-release-workflow
-
-          Release-Version: $RELEASE_VERSION
-          Release-Initiated-By: ${{ github.server_url }}/${{github.actor}}
-          Release-Workflow-Run: $GITHUB_REPO_URL/actions/runs/${{ github.run_id }}
-          Release-Notes: $RELEASE_NOTES_URL
-          EndOfFile
-
-          # Create temporary branch to push the release commit- required for PREVIEW releases
-          gh api --method POST /repos/:owner/:repo/git/refs -f ref="refs/heads/$TEMPORARY_BRANCH" -f sha="$GITHUB_SHA"
-
-          release_commit_id=$(gh api --method PUT /repos/:owner/:repo/contents/$VERSION_FILE_PATH \
-            --field branch="$TEMPORARY_BRANCH" \
-            --field message="@commit-message.txt" \
-            --field sha="$VERSION_FILE_INITIAL_SHA" \
-            --field content="$VERSION_FILE_RELEASE_CONTENT" --jq '.commit.sha')
-                    
-          cat << EndOfFile >> $GITHUB_OUTPUT
-          release_tag=$RELEASE_TAG
-          release_notes_url=$RELEASE_NOTES_URL
-          release_version=$RELEASE_VERSION
-          release_commit_id=$release_commit_id
-          version_file_path=$VERSION_FILE_PATH
-          version_file_release_sha=$VERSION_FILE_RELEASE_SHA
-          version_file_post_release_content=$VERSION_FILE_POST_RELEASE_CONTENT
-          EndOfFile
-          
+          github-app-id: ${{ inputs.GITHUB_APP_ID }}
+          github-app-private-key: ${{ secrets.GITHUB_APP_PRIVATE_KEY }} }
 
   create-artifacts:
     name: 🎊 Create artifacts
-    needs: [init, generate-version-update-commits, push-release-commit]
+    needs: [init, versioning, push-release-commit]
     runs-on: ubuntu-latest
     outputs:
-      ARTIFACT_SHA256SUMS: ${{ steps.record-hashes.outputs.ARTIFACT_SHA256SUMS }}
+      artifact-sha256sums: ${{ steps.act.outputs.artifact-sha256sums }}
     steps:
-      - uses: actions/checkout@v4
+      - id: act
+        uses: guardian/gha-scala-library-release-workflow/actions/create-artifacts@break-workflow-up-into-smaller-reusable-files
         with:
-          ref: ${{ needs.push-release-commit.outputs.release_commit_id }}
-      - uses: actions/setup-java@v4 # don't 'cache: sbt', at least until https://github.com/actions/setup-java/pull/564 is resolved
-        with:
-          distribution: corretto
-          java-version: ${{ needs.generate-version-update-commits.outputs.library_build_major_java_version }}
-      - uses: sbt/setup-sbt@v1.1.9
-      - name: Generate artifacts
-        run: |
-          cat << EndOfFile > sbt-commands.txt
-          set ThisBuild / homepage := Some(url("$GITHUB_REPO_URL"))
-          set ThisBuild / scmInfo  := Some(ScmInfo(url("$GITHUB_REPO_URL"), "$GITHUB_REPO_URL"))
-          set ThisBuild / developers := List(Developer("$GITHUB_REPOSITORY_OWNER", "$GITHUB_REPOSITORY_OWNER", "${{ needs.init.outputs.key_email }}", url("${{ github.server_url }}/$GITHUB_REPOSITORY_OWNER")))
-          set ThisBuild / publishTo := Some(Resolver.file("foobar", file("$LOCAL_ARTIFACTS_STAGING_PATH")))
-          set ThisBuild / releaseNotesURL := Some(url("${{ needs.push-release-commit.outputs.release_notes_url }}"))
-          EndOfFile
-          cat sbt-commands.txt
-          
-          sbt ";< sbt-commands.txt; +publish"
-      - name: Record SHA-256 hashes of artifacts
-        id: record-hashes
-        run: |
-          sudo apt-get install hashdeep -q > /dev/null
-          
-          cd $LOCAL_ARTIFACTS_STAGING_PATH
-          {
-            echo 'ARTIFACT_SHA256SUMS<<EOF'
-            sha256deep -r -l .
-            echo EOF
-          } >> "$GITHUB_OUTPUT"
-
-      - uses: actions/cache/save@v4
-        id: cache
-        with:
-          path: ${{ env.LOCAL_ARTIFACTS_STAGING_PATH }}
-          key: unsigned-${{ env.RUN_ATTEMPT_UID }}
+          release-commit-id: ${{ needs.push-release-commit.outputs.release-commit-id }}
+          release-notes-url: ${{ needs.push-release-commit.outputs.release-notes-url }}
+          library-build-major-java-version: ${{ needs.versioning.outputs.library-build-major-java-version }}
+          owner-email: ${{ needs.init.outputs.pgp-key-email }}
 
   sign:
     name: 🔒 Sign
     needs: [init, push-release-commit, create-artifacts]
     runs-on: ubuntu-latest
-    env:
-      KEY_FINGERPRINT: ${{ needs.init.outputs.key_fingerprint }}
     steps:
-      - id: generate-github-app-token
-        uses: actions/create-github-app-token@v2
+      - uses: guardian/gha-scala-library-release-workflow/actions/sign@break-workflow-up-into-smaller-reusable-files
         with:
-          app-id: ${{ inputs.GITHUB_APP_ID }}
-          private-key: ${{ secrets.GITHUB_APP_PRIVATE_KEY }} }
-      - uses: actions/checkout@v4
-        with:
-          path: repo
-          ref: ${{ needs.push-release-commit.outputs.release_commit_id }}
-          fetch-depth: 1 # For tag-signing, we only need the release commit - branch operations done with GitHub API
-          token: ${{ steps.generate-github-app-token.outputs.token }}
-          persist-credentials: true # Allow us to push as the GitHub App, and bypass branch ruleset
-      - uses: actions/cache/restore@v4
-        with:
-          path: ${{ env.LOCAL_ARTIFACTS_STAGING_PATH }}
-          key: unsigned-${{ env.RUN_ATTEMPT_UID }}
-          fail-on-cache-miss: true
-      - name: Verify artifact hashes before signing
-        env:
-          ARTIFACT_SHA256SUMS: ${{ needs.create-artifacts.outputs.ARTIFACT_SHA256SUMS }}
-        run: |
-          sudo apt-get install hashdeep -q > /dev/null
-          ARTIFACT_SHA256SUMS_FILE=$( mktemp )
-          printf "$ARTIFACT_SHA256SUMS" > $ARTIFACT_SHA256SUMS_FILE
-          
-          cd $LOCAL_ARTIFACTS_STAGING_PATH
-          echo "Checking artifact hashes..."
-          if [[ $(sha256deep -r -l -X "$ARTIFACT_SHA256SUMS_FILE" .) ]]
-          then
-            echo "::error title=Artifact hash verification failed::Artifacts for signing don't match the hash values recorded when they were generated."
-            exit 1
-          fi
-      - uses: actions/setup-java@v4
-        with:
-          distribution: corretto
-          java-version: 17
-          gpg-private-key: ${{ secrets.PGP_PRIVATE_KEY }}
-      - name: Sign artifacts
-        run: |
-          echo "KEY_FINGERPRINT=$KEY_FINGERPRINT"
-          find $LOCAL_ARTIFACTS_STAGING_PATH -type f -exec gpg -a --local-user "$KEY_FINGERPRINT" --detach-sign {} \;
-      - name: "Full Main-Branch release: Add release commit (from temporary release branch) to default branch"
-        if: needs.init.outputs.release_type == 'FULL_MAIN_BRANCH'
-        env:
-          GH_TOKEN: ${{ steps.generate-github-app-token.outputs.token }}
-          GH_REPO: ${{ github.repository }}
-          RELEASE_COMMIT_ID: ${{ needs.push-release-commit.outputs.release_commit_id }}
-        run: |
-          if gh api --silent --method PATCH /repos/:owner/:repo/git/refs/heads/$GITHUB_REF_NAME -f "sha=$RELEASE_COMMIT_ID"; then
-            echo "...fast-forward of default branch to include release commit succeeded"
-          else
-            echo "...fast-forward failed (commits added to default branch while release running?), will attempt a merge instead"
-            gh api --silent --method POST /repos/:owner/:repo/merges -f "base=$GITHUB_REF_NAME" -f "head=$RELEASE_COMMIT_ID"
-          fi
-      - name: Push signed tag
-        env:
-          RELEASE_TAG: ${{ needs.push-release-commit.outputs.release_tag }}
-          RELEASE_COMMIT_ID: ${{ needs.push-release-commit.outputs.release_commit_id }}
-          KEY_EMAIL: ${{ needs.init.outputs.key_email }}
-          ARTIFACT_SHA256SUMS: ${{ needs.create-artifacts.outputs.ARTIFACT_SHA256SUMS }}
-        run: |
-          cd $GITHUB_WORKSPACE/repo
-          git config user.email "$KEY_EMAIL"
-          git config user.name "$COMMITTER_NAME"
-          git config tag.gpgSign true
-          git config user.signingkey "$KEY_FINGERPRINT"
-          
-          cat << EndOfFile > tag-message.txt
-          Release $RELEASE_TAG initiated by $COMMITTER_NAME
-          
-          $ARTIFACT_SHA256SUMS
-          EndOfFile
-          
-          echo "Message is..."
-          cat tag-message.txt
-          
-          echo "Creating release tag (including artifact hashes)"
-          git tag -a -F tag-message.txt $RELEASE_TAG $RELEASE_COMMIT_ID
-          
-          echo "Pushing tag $RELEASE_TAG"
-          git push origin $RELEASE_TAG
-      - uses: actions/cache/save@v4
-        with:
-          path: ${{ env.LOCAL_ARTIFACTS_STAGING_PATH }}
-          key: signed-${{ env.RUN_ATTEMPT_UID }}
+          github-app-id: ${{ inputs.GITHUB_APP_ID }}
+          github-app-private-key: ${{ secrets.GITHUB_APP_PRIVATE_KEY }} }
+          pgp-key-email: ${{ needs.init.outputs.pgp-key-email }}
+          pgp-key-fingerprint: ${{ needs.init.outputs.pgp-key-fingerprint }}
+          pgp-private-key: ${{ secrets.PGP_PRIVATE_KEY }}
+          release-type: ${{ needs.init.outputs.release-type }}
+          release-tag: ${{ needs.push-release-commit.outputs.release-tag }}
+          release-commit-id: ${{ needs.push-release-commit.outputs.release-commit-id }}
+          artifact-sha256sums: ${{ needs.create-artifacts.outputs.artifact-sha256sums }}
 
   sonatype-release:
     name: 🔒 Sonatype Release
     needs: [push-release-commit, sign]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/cache/restore@v4
+      - uses: guardian/gha-scala-library-release-workflow/actions/sonatype-release@break-workflow-up-into-smaller-reusable-files
         with:
-          path: ${{ env.LOCAL_ARTIFACTS_STAGING_PATH }}
-          key: signed-${{ env.RUN_ATTEMPT_UID }}
-          fail-on-cache-miss: true
-      - name: Create tiny sbt project to perform Sonatype upload
-        env:
-          SONATYPE_TOKEN: ${{ secrets.SONATYPE_TOKEN }}
-        run: |
-          cat << EndOfFile > build.sbt
-          Global / stagingDirectory := new File("$LOCAL_ARTIFACTS_STAGING_PATH")
-          version := "${{ needs.push-release-commit.outputs.release_version }}"
-          sonaDeploymentName := "${{ github.repository }} $GITHUB_REF_NAME ${{ needs.push-release-commit.outputs.release_version }} $RUN_ATTEMPT_UID"
-          credentials += Credentials("Sonatype Central Portal", "central.sonatype.com", userName = "${SONATYPE_TOKEN%%:*}", passwd = "${SONATYPE_TOKEN#*:}")
-          EndOfFile
-          
-          mkdir project
-          echo 'sbt.version = 1.11.1' > project/build.properties
-          
-          ls -lR .
-      - uses: actions/setup-java@v4
-        with:
-          distribution: corretto
-          java-version: 21
-          cache: sbt # the issue described in https://github.com/actions/setup-java/pull/564 doesn't affect this step (no version.sbt)
-      - uses: sbt/setup-sbt@v1.1.9
-      - name: Release
-        run: |
-          sbt "sonaRelease"
+          release-version: ${{ needs.push-release-commit.outputs.release-version }}
+          sonatype-token: ${{ secrets.SONATYPE_TOKEN }}
 
-  github-release:
+  update-github:
     name: 🔒 Update GitHub
     needs:  [init, push-release-commit, sign]
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
-    env:
-      RELEASE_TAG: ${{ needs.push-release-commit.outputs.release_tag }}
-      RELEASE_VERSION: ${{ needs.push-release-commit.outputs.release_version }}
-      RELEASE_NOTES_URL: ${{ needs.push-release-commit.outputs.release_notes_url }}
-      GH_REPO: ${{ github.repository }}
     steps:
-      - id: generate-github-app-token
-        uses: actions/create-github-app-token@v2
+      - uses: guardian/gha-scala-library-release-workflow/actions/update-github@break-workflow-up-into-smaller-reusable-files
         with:
-          app-id: ${{ inputs.GITHUB_APP_ID }}
-          private-key: ${{ secrets.GITHUB_APP_PRIVATE_KEY }} }
-      - name: Clean-up temporary branch that was retaining the now-tagged release commit
-        env:
-          GH_TOKEN: ${{ steps.generate-github-app-token.outputs.token }}
-        run: |
-          gh api --method DELETE /repos/:owner/:repo/git/refs/heads/$TEMPORARY_BRANCH
-      - name: Common values
-        run: |
-          GITHUB_ACTIONS_PATH="$GITHUB_REPO_URL/actions"
-          GITHUB_WORKFLOW_FILE="release.yml" # Could be derived from $GITHUB_WORKFLOW_REF
-          GITHUB_WORKFLOW_URL="$GITHUB_ACTIONS_PATH/workflows/$GITHUB_WORKFLOW_FILE"
-          
-          cat << EndOfFile >> $GITHUB_ENV
-          GITHUB_WORKFLOW_FILE=$GITHUB_WORKFLOW_FILE
-          GITHUB_WORKFLOW_LINK=[GitHub UI]($GITHUB_WORKFLOW_URL)
-          GITHUB_WORKFLOW_RUN_LINK=[#${{ github.run_number }}]($GITHUB_ACTIONS_PATH/runs/${{ github.run_id }})
-          EndOfFile
-      - name: Create Github Release and update version.sbt post-release
-        if: needs.init.outputs.release_type == 'FULL_MAIN_BRANCH'
-        env:
-          GH_TOKEN: ${{ steps.generate-github-app-token.outputs.token }}
-        run: |
-          gh release create $RELEASE_TAG --verify-tag --generate-notes --notes "Release run: $GITHUB_WORKFLOW_RUN_LINK"
-          echo "GitHub Release notes: [$RELEASE_TAG]($RELEASE_NOTES_URL)" >> $GITHUB_STEP_SUMMARY
-          
-          cat << EndOfFile > commit-message.txt
-          Post-release of $RELEASE_TAG by @${{github.actor}}: set snapshot version
-          
-          Setting snapshot version after @${{github.actor}} published $RELEASE_NOTES_URL
-          EndOfFile
-          
-          gh api --method PUT /repos/:owner/:repo/contents/${{ needs.push-release-commit.outputs.version_file_path }} \
-            --field message="@commit-message.txt" \
-            --field sha="${{ needs.push-release-commit.outputs.version_file_release_sha }}" \
-            --field content="${{ needs.push-release-commit.outputs.version_file_post_release_content }}"
-      - name: Update PR with comment
-        if: needs.init.outputs.release_type == 'PREVIEW_FEATURE_BRANCH'
-        env:
-          GH_TOKEN: ${{ steps.generate-github-app-token.outputs.token }}
-        run: |
-          cat << EndOfFile > comment_body.txt
-          @${{github.actor}} has published a preview version of this PR with release workflow run $GITHUB_WORKFLOW_RUN_LINK, based on commit ${{ github.sha }}:
-          
-          $RELEASE_VERSION
-          
-          <details>
-          <summary>Want to make another preview release?</summary>
-          
-          Click 'Run workflow' in the $GITHUB_WORKFLOW_LINK, specifying the $GITHUB_REF_NAME branch, or use the [GitHub CLI](https://cli.github.com/) command:
-          
-          gh workflow run $GITHUB_WORKFLOW_FILE --ref $GITHUB_REF_NAME
-          
-          </details>
-          
-          <details>
-          <summary>Want to make a full release after this PR is merged?</summary>
-          
-          Click 'Run workflow' in the $GITHUB_WORKFLOW_LINK, leaving the branch as the default, or use the [GitHub CLI](https://cli.github.com/) command:
-          
-          gh workflow run $GITHUB_WORKFLOW_FILE
-          
-          </details>
-          EndOfFile
-          
-          cat comment_body.txt
-          
-          gh pr comment ${{ github.ref_name }} --body-file comment_body.txt >> $GITHUB_STEP_SUMMARY
+          release-type: ${{ needs.init.outputs.release-type }}
+          release-tag: ${{ needs.push-release-commit.outputs.release-tag }}
+          release-version: ${{ needs.push-release-commit.outputs.release-version }}
+          release-notes-url: ${{ needs.push-release-commit.outputs.release-notes_url }}
+          temporary-branch: ${{ needs.push-release-commit.outputs.temporary-branch }}
+          github-app-id: ${{ inputs.GITHUB_APP_ID }}
+          github-app-private-key: ${{ secrets.GITHUB_APP_PRIVATE_KEY }} }
+          version-file-path: ${{ needs.push-release-commit.outputs.version-file-path }}
+          version-file-post-release-content: ${{ needs.push-release-commit.outputs.version-file-post-release-content }}
+          version-file-release-sha: ${{ needs.push-release-commit.outputs.version-file-release-sha }}

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -44,7 +44,7 @@ jobs:
       version-suffix: ${{ steps.act.outputs.version-suffix }}
     steps:
       - id: act
-        uses: guardian/gha-scala-library-release-workflow/actions/init@break-workflow-up-into-smaller-reusable-files
+        uses: guardian/gha-scala-library-release-workflow/actions/init@main
         with:
           pgp-private-key: ${{ secrets.PGP_PRIVATE_KEY }}
 
@@ -56,7 +56,7 @@ jobs:
       library-build-major-java-version: ${{ steps.act.outputs.library-build-major-java-version }}
     steps:
       - id: act
-        uses: guardian/gha-scala-library-release-workflow/actions/versioning@break-workflow-up-into-smaller-reusable-files
+        uses: guardian/gha-scala-library-release-workflow/actions/versioning@main
         with:
           version-suffix: ${{ needs.init.outputs.version-suffix }}
 
@@ -83,7 +83,7 @@ jobs:
       temporary-branch: ${{ steps.act.outputs.temporary-branch }}
     steps:
       - id: act
-        uses: guardian/gha-scala-library-release-workflow/actions/push-release-commit@break-workflow-up-into-smaller-reusable-files
+        uses: guardian/gha-scala-library-release-workflow/actions/push-release-commit@main
         with:
           github-app-id: ${{ inputs.GITHUB_APP_ID }}
           github-app-private-key: ${{ secrets.GITHUB_APP_PRIVATE_KEY }} }
@@ -96,7 +96,7 @@ jobs:
       artifact-sha256sums: ${{ steps.act.outputs.artifact-sha256sums }}
     steps:
       - id: act
-        uses: guardian/gha-scala-library-release-workflow/actions/create-artifacts@break-workflow-up-into-smaller-reusable-files
+        uses: guardian/gha-scala-library-release-workflow/actions/create-artifacts@main
         with:
           release-commit-id: ${{ needs.push-release-commit.outputs.release-commit-id }}
           release-notes-url: ${{ needs.push-release-commit.outputs.release-notes-url }}
@@ -108,7 +108,7 @@ jobs:
     needs: [init, push-release-commit, create-artifacts]
     runs-on: ubuntu-latest
     steps:
-      - uses: guardian/gha-scala-library-release-workflow/actions/sign@break-workflow-up-into-smaller-reusable-files
+      - uses: guardian/gha-scala-library-release-workflow/actions/sign@main
         with:
           github-app-id: ${{ inputs.GITHUB_APP_ID }}
           github-app-private-key: ${{ secrets.GITHUB_APP_PRIVATE_KEY }} }
@@ -125,7 +125,7 @@ jobs:
     needs: [push-release-commit, sign]
     runs-on: ubuntu-latest
     steps:
-      - uses: guardian/gha-scala-library-release-workflow/actions/sonatype-release@break-workflow-up-into-smaller-reusable-files
+      - uses: guardian/gha-scala-library-release-workflow/actions/sonatype-release@main
         with:
           release-version: ${{ needs.push-release-commit.outputs.release-version }}
           sonatype-token: ${{ secrets.SONATYPE_TOKEN }}
@@ -138,7 +138,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: guardian/gha-scala-library-release-workflow/actions/update-github@break-workflow-up-into-smaller-reusable-files
+      - uses: guardian/gha-scala-library-release-workflow/actions/update-github@main
         with:
           release-type: ${{ needs.init.outputs.release-type }}
           release-tag: ${{ needs.push-release-commit.outputs.release-tag }}

--- a/actions/create-artifacts/action.yml
+++ b/actions/create-artifacts/action.yml
@@ -1,0 +1,66 @@
+name: '🎊 Create artifacts'
+description: "Create an unsigned file tree artifact suitable for uploading to Sonatype Central Portal - top-level folder will be 'com' for 'com.gu' group id"
+inputs:
+  release-commit-id:
+    description: "The git commit-id SHA for the actual release commit"
+    required: true
+  release-notes-url:
+    description: "Either a GitHub Release url ('https://github.com/guardian/etag-caching/releases/tag/v8.1.6') or the PR url for a Preview release ('https://github.com/guardian/etag-caching/pull/65')"
+    required: true
+  library-build-major-java-version:
+    description: "The major version of Java (eg '21', '17', or '11') the library should be built with"
+    required: true
+  owner-email:
+    description: "Email address for the owner of this project (eg. derived from signing PGP key)"
+    required: true
+
+outputs:
+  artifact-sha256sums:
+    description: "Output from hashdeep - SHA-256 hashes for all artifact files (.jar, pom, etc)"
+    value: ${{ steps.record-hashes.outputs.artifact-sha256sums }}
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.release-commit-id }}
+    - uses: actions/setup-java@v4 # don't 'cache: sbt', at least until https://github.com/actions/setup-java/pull/564 is resolved
+      with:
+        distribution: corretto
+        java-version: ${{ inputs.library-build-major-java-version }}
+    - uses: sbt/setup-sbt@v1.1.9
+    - name: Generate artifacts
+      shell: bash
+      env:
+        GITHUB_REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+      run: |
+        cat << EndOfFile > sbt-commands.txt
+        set ThisBuild / homepage := Some(url("$GITHUB_REPO_URL"))
+        set ThisBuild / scmInfo  := Some(ScmInfo(url("$GITHUB_REPO_URL"), "$GITHUB_REPO_URL"))
+        set ThisBuild / developers := List(Developer("$GITHUB_REPOSITORY_OWNER", "$GITHUB_REPOSITORY_OWNER", "${{ inputs.owner-email }}", url("${{ github.server_url }}/$GITHUB_REPOSITORY_OWNER")))
+        set ThisBuild / publishTo := Some(Resolver.file("foobar", file("/tmp/artifact_staging")))
+        set ThisBuild / releaseNotesURL := Some(url("${{ inputs.release-notes-url }}"))
+        EndOfFile
+        cat sbt-commands.txt
+        
+        sbt ";< sbt-commands.txt; +publish"
+    - name: Record SHA-256 hashes of artifacts
+      id: record-hashes
+      shell: bash
+      run: |
+        sudo apt-get install hashdeep -q > /dev/null
+        
+        cd /tmp/artifact_staging
+        {
+          echo 'artifact-sha256sums<<EOF'
+          sha256deep -r -l .
+          echo EOF
+        } >> "$GITHUB_OUTPUT"
+
+    - uses: actions/upload-artifact@v4
+      with:
+        path: /tmp/artifact_staging
+        name: unsigned-artifacts
+        retention-days: 1 # we'll have an additional copy of these files in 'signed-artifacts'
+

--- a/actions/init/action.yml
+++ b/actions/init/action.yml
@@ -1,0 +1,66 @@
+name: 🔒 Init
+description: Establish initial values for this release - eg, is this a Preview release?
+inputs:
+  pgp-private-key:
+    description: 'A passwordless PGP key'
+    required: true
+outputs:
+  pgp-key-fingerprint:
+    description: "PGP key fingerprint so we can sign artifacts using the correct key later on"
+    value: ${{ steps.read-identifiers.outputs.pgp-key-fingerprint }}
+  pgp-key-email:
+    description: "Email address, derived from signing PGP key"
+    value: ${{ steps.read-identifiers.outputs.pgp-key-email }}
+  release-type:
+    description: "Either 'FULL_MAIN_BRANCH' or 'PREVIEW_FEATURE_BRANCH'"
+    value: ${{ steps.generate-version-suffix.outputs.release-type }}
+  version-suffix:
+    description: "If this is a preview release, a uniquely-identifying suffix"
+    value: ${{ steps.generate-version-suffix.outputs.version-suffix }}
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/setup-java@v4
+      with:
+        distribution: corretto
+        java-version: 21
+        gpg-private-key: ${{ inputs.pgp-private-key }}
+    - name: Read Identifiers from Signing Key
+      id: read-identifiers
+      shell: bash
+      run: |
+        key_fingerprint_and_email=$(gpg2 --list-secret-keys --list-options show-only-fpr-mbox)
+        key_fingerprint=$(echo $key_fingerprint_and_email | awk '{print $1}')
+        key_email=$(echo $key_fingerprint_and_email | awk '{print $2}')
+        echo "key_fingerprint=$key_fingerprint"
+        
+        cat << EndOfFile >> $GITHUB_OUTPUT
+        pgp-key-fingerprint=$key_fingerprint
+        pgp-key-email=$key_email
+        EndOfFile
+        if ! [[ "$key_fingerprint" =~ ^[[:xdigit:]]{8,}$ ]]; then
+          echo "::error title=Missing PGP key::Has PGP_PRIVATE_KEY been set correctly? https://github.com/guardian/gha-scala-library-release-workflow/blob/main/docs/credentials/supplying-credentials.md"
+          exit 1
+        fi
+    - name: Check for default branch
+      id: generate-version-suffix
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: |
+        default_branch=$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name ${{ github.repository }})
+        
+        if [[ "$default_branch" = $GITHUB_REF_NAME ]]; then
+          release_type="FULL_MAIN_BRANCH"
+          version_suffix=""
+        else
+          release_type="PREVIEW_FEATURE_BRANCH"
+          version_suffix="-PREVIEW.${GITHUB_REF_NAME//[^[:alnum:]-]/}.$(date +%Y-%m-%dT%H%M).${GITHUB_SHA:0:8}"
+        fi
+        
+        echo "current branch: $GITHUB_REF_NAME, release_type: $release_type, version_suffix: $version_suffix"
+        cat << EndOfFile >> $GITHUB_OUTPUT
+        release-type=$release_type
+        version-suffix=$version_suffix
+        EndOfFile

--- a/actions/push-release-commit/action.yml
+++ b/actions/push-release-commit/action.yml
@@ -1,0 +1,127 @@
+name: '🔒 Push Release Commit'
+description: 'Push the release commit to a temporary branch'
+inputs:
+  github-app-id:
+    description:
+      "App ID for a GitHub App that is allowed to push directly to the default branch. Eg, App ID on:
+      https://github.com/organizations/guardian/settings/apps/gu-scala-library-release"
+    required: true
+  github-app-private-key:
+    description:
+      "See https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/managing-private-keys-for-github-apps#generating-private-keys
+      Should be in normal plaintext format, starting '-----BEGIN RSA PRIVATE KEY-----'"
+    required: true
+outputs:
+  release-tag:
+    description: "Eg 'v1.2.4' - with the 'v' prefix"
+    value: ${{ steps.create-commit.outputs.release-tag }}
+  release-version:
+    description: "The artifact version being released, eg '1.2.4' - without a prefix"
+    value: ${{ steps.create-commit.outputs.release-version }}
+  release-commit-id:
+    description: "The git commit-id SHA for the actual release commit"
+    value: ${{ steps.create-commit.outputs.release-commit-id }}
+  release-notes-url:
+    description: "Either a GitHub Release url ('https://github.com/guardian/etag-caching/releases/tag/v8.1.6') or the PR url for a Preview release ('https://github.com/guardian/etag-caching/pull/65')"
+    value: ${{ steps.create-commit.outputs.release-notes-url }}
+  version-file-path:
+    description: "eg. version.sbt"
+    value: ${{ steps.create-commit.outputs.version-file-path }}
+  version-file-release-sha:
+    description: "the SHA of the version.sbt file when it has the non-snapshot release version in it"
+    value: ${{ steps.create-commit.outputs.version-file-release-sha }}
+  version-file-post-release-content:
+    description: "the contents of the version.sbt file after the release - with the '-SNAPSHOT' suffix reinstated"
+    value: ${{ steps.create-commit.outputs.version-file-post-release-content }}
+  temporary-branch:
+    description: "The temporary branch that the release commit was pushed to"
+    value: ${{ steps.create-commit.outputs.temporary-branch }}
+
+runs:
+  using: "composite"
+  steps:
+    - id: generate-github-app-token
+      uses: actions/create-github-app-token@v2
+      with:
+        app-id: ${{ inputs.github-app-id }}
+        private-key: ${{ inputs.github-app-private-key }} }
+    - uses: actions/checkout@v4
+      with:
+        path: repo
+    - uses: actions/download-artifact@v4
+      with:
+        name: unverified-version-updates
+    - name: Create commit
+      id: create-commit
+      shell: bash
+      env:
+        GH_TOKEN: ${{ steps.generate-github-app-token.outputs.token }}
+        GH_REPO: ${{ github.repository }}
+        GITHUB_REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+      run: |
+        echo "GITHUB_REF_NAME=$GITHUB_REF_NAME"
+        echo "GITHUB_REF=$GITHUB_REF"
+        
+        tar -xvf unverified-version-updates.git.tar
+        cd unverified-version-updates.git
+        
+        RELEASE_TAG=$(git describe --tags --abbrev=0)
+        
+        echo "Retrieved RELEASE_TAG=$RELEASE_TAG"
+        
+        cd ../repo
+        
+        git remote add unsigned ../unverified-version-updates.git
+        git fetch unsigned
+        
+        RELEASE_VERSION=${RELEASE_TAG#"v"}
+        
+        echo "RELEASE_VERSION=$RELEASE_VERSION"
+        
+        if [[ "${{ inputs.release-type }}" = "FULL_MAIN_BRANCH" ]]; then
+          RELEASE_NOTES_URL=$GITHUB_REPO_URL/releases/tag/$RELEASE_TAG
+        else
+          # Use the PR url as the release notes url when doing a 'preview' release
+          RELEASE_NOTES_URL=$( gh pr view $GITHUB_REF_NAME --json url -q .url )
+        fi
+        
+        VERSION_FILE_PATH=$(git diff-tree --no-commit-id --name-only -r $RELEASE_TAG | grep version.sbt)
+        VERSION_FILE_INITIAL_SHA=$( git rev-parse $GITHUB_REF:$VERSION_FILE_PATH )
+        VERSION_FILE_RELEASE_SHA=$( git rev-parse $RELEASE_TAG:$VERSION_FILE_PATH )
+        VERSION_FILE_RELEASE_CONTENT=$( git cat-file blob $RELEASE_TAG:$VERSION_FILE_PATH | base64 -w0)
+        VERSION_FILE_POST_RELEASE_CONTENT=$( git cat-file blob unsigned/$GITHUB_REF_NAME:$VERSION_FILE_PATH | base64 -w0)
+
+        cd ..
+        
+        cat << EndOfFile > commit-message.txt
+        $RELEASE_TAG published by ${{github.actor}}
+        
+        ${{github.actor}} published release version $RELEASE_VERSION
+        using gha-scala-library-release-workflow: https://github.com/guardian/gha-scala-library-release-workflow
+
+        Release-Version: $RELEASE_VERSION
+        Release-Initiated-By: ${{ github.server_url }}/${{github.actor}}
+        Release-Workflow-Run: $GITHUB_REPO_URL/actions/runs/${{ github.run_id }}
+        Release-Notes: $RELEASE_NOTES_URL
+        EndOfFile
+
+        # Create temporary branch to push the release commit
+        TEMPORARY_BRANCH=release-workflow/temporary/${{ github.run_id }}
+        gh api --method POST /repos/:owner/:repo/git/refs -f ref="refs/heads/$TEMPORARY_BRANCH" -f sha="$GITHUB_SHA"
+
+        release_commit_id=$(gh api --method PUT /repos/:owner/:repo/contents/$VERSION_FILE_PATH \
+          --field branch="$TEMPORARY_BRANCH" \
+          --field message="@commit-message.txt" \
+          --field sha="$VERSION_FILE_INITIAL_SHA" \
+          --field content="$VERSION_FILE_RELEASE_CONTENT" --jq '.commit.sha')
+        
+        cat << EndOfFile >> $GITHUB_OUTPUT
+        release-tag=$RELEASE_TAG
+        release-notes-url=$RELEASE_NOTES_URL
+        release-version=$RELEASE_VERSION
+        release-commit-id=$release_commit_id
+        temporary-branch=$TEMPORARY_BRANCH
+        version-file-path=$VERSION_FILE_PATH
+        version-file-release-sha=$VERSION_FILE_RELEASE_SHA
+        version-file-post-release-content=$VERSION_FILE_POST_RELEASE_CONTENT
+        EndOfFile

--- a/actions/sign/action.yml
+++ b/actions/sign/action.yml
@@ -1,0 +1,123 @@
+name: '🔒 Sign'
+description: 'Sign artifacts with PGP key'
+inputs:
+  release-type:
+    description: "Either 'FULL_MAIN_BRANCH' or 'PREVIEW_FEATURE_BRANCH'"
+    required: true
+  release-tag:
+    description: "Eg 'v1.2.4' - with the 'v' prefix"
+    required: true
+  release-commit-id:
+    description: "The git commit-id SHA for the actual release commit"
+    required: true
+  pgp-key-fingerprint:
+    description: 'PGP key fingerprint'
+    required: true
+  pgp-key-email:
+    description: 'Email address used when git-authoring the signed tag - must match PGP key'
+    required: true
+  pgp-private-key:
+    description: "A passphrase-less PGP private key used to sign artifacts, commits, & tags.
+          Should be in normal plaintext (ASCII-armored) format, starting 'BEGIN PGP PUBLIC KEY BLOCK', with no additional BASE64-encoding."
+    required: true
+  github-app-id:
+    description:
+      "App ID for a GitHub App that is allowed to push directly to the default branch. Eg, App ID on:
+      https://github.com/organizations/guardian/settings/apps/gu-scala-library-release"
+    required: true
+  github-app-private-key:
+    description:
+      "See https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/managing-private-keys-for-github-apps#generating-private-keys
+      Should be in normal plaintext format, starting '-----BEGIN RSA PRIVATE KEY-----'"
+    required: true
+  artifact-sha256sums:
+    description: 'Output from hashdeep - SHA-256 hashes for all artifact files (.jar, pom, etc)'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - id: generate-github-app-token
+      uses: actions/create-github-app-token@v2
+      with:
+        app-id: ${{ inputs.github-app-id }}
+        private-key: ${{ inputs.github-app-private-key }} }
+    - uses: actions/checkout@v4
+      with:
+        path: repo
+        ref: ${{ inputs.release-commit-id }}
+        fetch-depth: 1 # For tag-signing, we only need the release commit - branch operations done with GitHub API
+        token: ${{ steps.generate-github-app-token.outputs.token }}
+        persist-credentials: true # Allow us to push as the GitHub App, and bypass branch ruleset
+
+    - uses: actions/download-artifact@v4
+      with:
+        path: /tmp/artifact_staging
+        name: unsigned-artifacts
+    - name: Verify artifact hashes before signing
+      shell: bash
+      run: |
+        sudo apt-get install hashdeep -q > /dev/null
+        ARTIFACT_SHA256SUMS_FILE=$( mktemp )
+        printf "${{inputs.artifact-sha256sums}}" > $ARTIFACT_SHA256SUMS_FILE
+        
+        cd /tmp/artifact_staging
+        echo "Checking artifact hashes..."
+        if [[ $(sha256deep -r -l -X "$ARTIFACT_SHA256SUMS_FILE" .) ]]
+        then
+          echo "::error title=Artifact hash verification failed::Artifacts for signing don't match the hash values recorded when they were generated."
+          exit 1
+        fi
+    - uses: actions/setup-java@v4
+      with:
+        distribution: corretto
+        java-version: 21
+        gpg-private-key: ${{ inputs.pgp-private-key }}
+    - name: Sign artifacts
+      shell: bash
+      run: |
+        echo "KEY_FINGERPRINT=${{inputs.pgp-key-fingerprint}}"
+        find /tmp/artifact_staging -type f -exec gpg -a --local-user "${{inputs.pgp-key-fingerprint}}" --detach-sign {} \;
+    - name: "Full Main-Branch release: Add release commit (from temporary release branch) to default branch"
+      if: inputs.release-type == 'FULL_MAIN_BRANCH'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ steps.generate-github-app-token.outputs.token }}
+        GH_REPO: ${{ github.repository }}
+        RELEASE_COMMIT_ID: ${{ inputs.release-commit-id }}
+      run: |
+        if gh api --silent --method PATCH /repos/:owner/:repo/git/refs/heads/$GITHUB_REF_NAME -f "sha=${{inputs.release-commit-id}}"; then
+          echo "...fast-forward of default branch to include release commit succeeded"
+        else
+          echo "...fast-forward failed (commits added to default branch while release running?), will attempt a merge instead"
+          gh api --silent --method POST /repos/:owner/:repo/merges -f "base=$GITHUB_REF_NAME" -f "head=${{inputs.release-commit-id}}"
+        fi
+    - name: Push signed tag
+      shell: bash
+      env:
+        COMMITTER_NAME: "@${{github.actor}} using gha-scala-library-release-workflow"
+      run: |
+        cd $GITHUB_WORKSPACE/repo
+        git config user.email "${{inputs.pgp-key-email}}"
+        git config user.name "$COMMITTER_NAME"
+        git config tag.gpgSign true
+        git config user.signingkey "${{inputs.pgp-key-fingerprint}}"
+        
+        cat << EndOfFile > tag-message.txt
+        Release ${{inputs.release-tag}} initiated by $COMMITTER_NAME
+        
+        ${{inputs.artifact-sha256sums}}
+        EndOfFile
+        
+        echo "Message is..."
+        cat tag-message.txt
+        
+        echo "Creating release tag (including artifact hashes)"
+        git tag -a -F tag-message.txt ${{inputs.release-tag}} ${{inputs.release-commit-id}}
+        
+        echo "Pushing tag ${{inputs.release-tag}}"
+        git push origin ${{inputs.release-tag}}
+    - uses: actions/upload-artifact@v4
+      with:
+        path: /tmp/artifact_staging
+        name: signed-artifacts

--- a/actions/sonatype-release/action.yml
+++ b/actions/sonatype-release/action.yml
@@ -1,0 +1,43 @@
+name: '🔒 Sonatype Release'
+description: 'Upload artifact bundle to Sonatype Central Portal'
+inputs:
+  release-version:
+    description: "The artifact version being released, eg '1.2.4' - without a prefix"
+    required: true
+  sonatype-token:
+    description: 'Sonatype authentication token, colon-separated (username:password) - https://central.sonatype.org/publish/generate-token/'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/download-artifact@v4
+      with:
+        path: /tmp/artifact_staging
+        name: signed-artifacts
+    - name: Create tiny sbt project to perform Sonatype upload
+      shell: bash
+      env:
+        SONATYPE_TOKEN: ${{ inputs.sonatype-token }}
+      run: |
+        cat << EndOfFile > build.sbt
+        Global / stagingDirectory := new File("/tmp/artifact_staging")
+        version := "${{ inputs.release-version }}"
+        sonaDeploymentName := "${{ github.repository }} $GITHUB_REF_NAME ${{ inputs.release-version }} ${{ github.run_id }}-${{ github.run_attempt }}"
+        credentials += Credentials("Sonatype Central Portal", "central.sonatype.com", userName = "${SONATYPE_TOKEN%%:*}", passwd = "${SONATYPE_TOKEN#*:}")
+        EndOfFile
+        
+        mkdir project
+        echo 'sbt.version = 1.11.1' > project/build.properties
+        
+        ls -lR .
+    - uses: actions/setup-java@v4
+      with:
+        distribution: corretto
+        java-version: 21
+        cache: sbt # the issue described in https://github.com/actions/setup-java/pull/564 doesn't affect this step (no version.sbt)
+    - uses: sbt/setup-sbt@v1.1.9
+    - name: Release
+      shell: bash
+      run: |
+        sbt "sonaRelease"

--- a/actions/update-github/action.yml
+++ b/actions/update-github/action.yml
@@ -1,0 +1,113 @@
+name: '🔒 Update GitHub'
+description: 'Update GitHub with details post-release'
+inputs:
+  release-type:
+    description: "Either 'FULL_MAIN_BRANCH' or 'PREVIEW_FEATURE_BRANCH'"
+    required: true
+  release-tag:
+    description: "Eg 'v1.2.4' - with the 'v' prefix"
+    required: true
+  release-version:
+    description: "The artifact version being released, eg '1.2.4' - without a prefix"
+    required: true
+  release-notes-url:
+    description: "Either a GitHub Release url ('https://github.com/guardian/etag-caching/releases/tag/v8.1.6') or the PR url for a Preview release ('https://github.com/guardian/etag-caching/pull/65')"
+    required: true
+  temporary-branch:
+    description: "The temporary branch that the release commit was pushed to"
+    required: true
+  github-app-id:
+    description:
+      "App ID for a GitHub App that is allowed to push directly to the default branch. Eg, App ID on:
+      https://github.com/organizations/guardian/settings/apps/gu-scala-library-release"
+    required: true
+  github-app-private-key:
+    description:
+      "See https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/managing-private-keys-for-github-apps#generating-private-keys
+      Should be in normal plaintext format, starting '-----BEGIN RSA PRIVATE KEY-----'"
+    required: true
+  version-file-path:
+    description: "eg. version.sbt"
+    required: true
+  version-file-release-sha:
+    description: "the SHA of the version.sbt file when it has the non-snapshot release version in it"
+    required: true
+  version-file-post-release-content:
+    description: "the contents of the version.sbt file after the release - with the '-SNAPSHOT' suffix reinstated"
+    required: true
+
+runs:
+  using: "composite"
+
+  steps:
+    - id: generate-github-app-token
+      uses: actions/create-github-app-token@v2
+      with:
+        app-id: ${{ inputs.github-app-id }}
+        private-key: ${{ inputs.github-app-private-key }} }
+    - name: Add common values to the GITHUB_ENV - note all subsequent steps have access to the GitHub token with GH_TOKEN
+      shell: bash
+      run: |
+        GITHUB_ACTIONS_PATH="${{ github.server_url }}/${{ github.repository }}/actions"
+        GITHUB_WORKFLOW_FILE="release.yml" # Could be derived from $GITHUB_WORKFLOW_REF
+        GITHUB_WORKFLOW_URL="$GITHUB_ACTIONS_PATH/workflows/$GITHUB_WORKFLOW_FILE"
+
+        cat << EndOfFile >> $GITHUB_ENV
+        GH_REPO=${{ github.repository }}
+        GH_TOKEN=${{ steps.generate-github-app-token.outputs.token }}
+        GITHUB_WORKFLOW_FILE=$GITHUB_WORKFLOW_FILE
+        GITHUB_WORKFLOW_LINK=[GitHub UI]($GITHUB_WORKFLOW_URL)
+        GITHUB_WORKFLOW_RUN_LINK=[#${{ github.run_number }}]($GITHUB_ACTIONS_PATH/runs/${{ github.run_id }})
+        EndOfFile
+    - name: Clean-up temporary branch that was retaining the now-tagged release commit
+      shell: bash
+      run: |
+        gh api --method DELETE /repos/:owner/:repo/git/refs/heads/${{inputs.temporary-branch}}
+    - name: Create Github Release and update version.sbt post-release
+      if: inputs.release-type == 'FULL_MAIN_BRANCH'
+      shell: bash
+      run: |
+        gh release create ${{inputs.release-tag}} --verify-tag --generate-notes --notes "Release run: $GITHUB_WORKFLOW_RUN_LINK"
+        echo "GitHub Release notes: [${{inputs.release-tag}}](${{inputs.release-notes-url}})" >> $GITHUB_STEP_SUMMARY
+        
+        cat << EndOfFile > commit-message.txt
+        Post-release of ${{inputs.release-tag}} by @${{github.actor}}: set snapshot version
+        
+        Setting snapshot version after @${{github.actor}} published ${{inputs.release-notes-url}}
+        EndOfFile
+        
+        gh api --method PUT /repos/:owner/:repo/contents/${{ inputs.version-file-path }} \
+          --field message="@commit-message.txt" \
+          --field sha="${{ inputs.version-file-release-sha }}" \
+          --field content="${{ inputs.version-file-post-release-content }}"
+    - name: Update PR with comment
+      if: inputs.release-type == 'PREVIEW_FEATURE_BRANCH'
+      shell: bash
+      run: |
+        cat << EndOfFile > comment_body.txt
+        @${{github.actor}} has published a preview version of this PR with release workflow run $GITHUB_WORKFLOW_RUN_LINK, based on commit ${{ github.sha }}:
+        
+        ${{ inputs.release-version }}
+        
+        <details>
+        <summary>Want to make another preview release?</summary>
+        
+        Click 'Run workflow' in the $GITHUB_WORKFLOW_LINK, specifying the $GITHUB_REF_NAME branch, or use the [GitHub CLI](https://cli.github.com/) command:
+        
+        gh workflow run $GITHUB_WORKFLOW_FILE --ref $GITHUB_REF_NAME
+        
+        </details>
+        
+        <details>
+        <summary>Want to make a full release after this PR is merged?</summary>
+        
+        Click 'Run workflow' in the $GITHUB_WORKFLOW_LINK, leaving the branch as the default, or use the [GitHub CLI](https://cli.github.com/) command:
+        
+        gh workflow run $GITHUB_WORKFLOW_FILE
+        
+        </details>
+        EndOfFile
+        
+        cat comment_body.txt
+        
+        gh pr comment ${{ github.ref_name }} --body-file comment_body.txt >> $GITHUB_STEP_SUMMARY

--- a/actions/versioning/action.yml
+++ b/actions/versioning/action.yml
@@ -1,0 +1,71 @@
+name: '🎊 Versioning'
+description: 'Use automated-compatibility-checking to establish the appropriate version number'
+inputs:
+  version-suffix:
+    description: "If this is a preview release, a uniquely-identifying suffix. Otherwise, empty."
+    required: true
+outputs:
+  library-build-major-java-version:
+    description: "The major version of Java (eg '21', '17', or '11') the library should be built with"
+    value: ${{ steps.establish_java_for_library_build.outputs.library-build-major-java-version }}
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v4
+    - id: establish_java_for_library_build
+      name: Establish library build Java version
+      shell: bash
+      run: |
+        if [ ! -f .tool-versions ]; then
+        echo "::error title=Missing .tool-versions file::gha-scala-library-release-workflow requires an asdf-format .tool-versions file to establish the Java version for the build."
+        exit 1
+        fi
+        LIBRARY_BUILD_MAJOR_JAVA_VERSION=$( grep -Eo 'java [[:alnum:]-]+-[[:digit:]]+' .tool-versions | rev | cut -d'-' -f1 | rev )
+        echo "Using Java $LIBRARY_BUILD_MAJOR_JAVA_VERSION"
+        if [ -z "${LIBRARY_BUILD_MAJOR_JAVA_VERSION}" ]; then
+        echo "::error title=Missing Java version in .tool-versions file::Could not establish the library's required Java version - the '.tool-versions' file should have a line like 'java corretto-21.0.3.9.1'."
+        exit 1
+        fi
+        
+        cat << EndOfFile >> $GITHUB_OUTPUT
+        library-build-major-java-version=$LIBRARY_BUILD_MAJOR_JAVA_VERSION
+        EndOfFile
+    - uses: actions/setup-java@v4 # don't 'cache: sbt', at least until https://github.com/actions/setup-java/pull/564 is merged
+      with:
+        distribution: corretto
+        java-version: ${{ steps.establish_java_for_library_build.outputs.library-build-major-java-version }}
+    - uses: sbt/setup-sbt@v1.1.9
+    - name: Use sbt-release to construct version.sbt updates
+      shell: bash
+      run: |
+        git config user.email "example@example.com"
+        git config user.name "Ephemeral commit created only for extracting version commit information"
+        
+        sbt_commands_file=$(mktemp)
+        cat << EndOfFile > $sbt_commands_file
+        set releaseVersion := releaseVersion.value.andThen(_ + "${{ inputs.version-suffix }}")
+        release with-defaults
+        EndOfFile
+        cat $sbt_commands_file
+        sbt ";< $sbt_commands_file"
+        
+        echo $GITHUB_WORKSPACE
+        cd `mktemp -d`
+        git clone --bare $GITHUB_WORKSPACE unverified-version-updates.git
+        tar -cvf unverified-version-updates.git.tar unverified-version-updates.git
+        
+        cat << EndOfFile >> $GITHUB_ENV
+        BARE_REPO_PATH=$(pwd)/unverified-version-updates.git.tar
+        EndOfFile
+        
+        
+        cd unverified-version-updates.git
+        cat << EndOfFile >> $GITHUB_STEP_SUMMARY
+        # Release $(git describe --tags --abbrev=0)
+        Library built with Java ${{ steps.establish_java_for_library_build.outputs.library-build-major-java-version }}.
+        EndOfFile
+    - uses: actions/upload-artifact@v4
+      with:
+        path: ${{ env.BARE_REPO_PATH }}
+        name: unverified-version-updates


### PR DESCRIPTION
This change enables a lot of code-reuse with the new Gradle release workflow:

* https://github.com/guardian/gha-gradle-library-release-workflow/pull/1

## Changes

* The bulk of the reusable workflow file has been extracted into a suite of 7 GitHub _Actions_ (specifically [composite actions](https://docs.github.com/en/actions/tutorials/creating-a-composite-action)), each of which correspond to the 7 existing jobs in the flow.
  * As GitHub Actions have a convention that their parameters are 'dash-case', a lot of the parameters have switched from snake-case (`release_type` ...with an underscore) to dash-case (`release-type` ...with a hyphen). This change means that we should probably make the next release of `gha-scala-library-release-workflow` have a major-version-bump, eg to v3.
  * The 5 global environment variables in the reusable workflow have been removed, to improve encapsulation of the 7 GitHub Actions - ie to be. more explicit about what inputs they're actually using.
  * Unfortunately there's [no](https://github.com/orgs/community/discussions/18601#discussioncomment-13296390) easy way to express that a GitHub Action should run using the same commit as the reusable-workflow file that called it (tho' [it is possible for workflow-to-workflow](https://docs.github.com/en/actions/how-tos/sharing-automations/reusing-workflows#:~:text=If%20you%20use%20the%20second%20syntax%20option%20(without%20%7Bowner%7D/%7Brepo%7D%20and%20%40%7Bref%7D)%20the%20called%20workflow%20is%20from%20the%20same%20commit%20as%20the%20caller%20workflow.%20Ref%20prefixes%20such%20as%20refs/heads%20and%20refs/tags%20are%20not%20allowed.%20You%20cannot%20use%20contexts%20or%20expressions%20in%20this%20keyword.)). Consequently for this PR, all the references to those GitHub actions have a `@break-workflow-up-into-smaller-reusable-files` reference - which needs to be switched to `@main` before merge
* For passing files between jobs, we switch from using GitHub Actions _caching_ infrastructure to [using artifacts](https://docs.github.com/en/actions/how-tos/writing-workflows/choosing-what-your-workflow-does/storing-and-sharing-data-from-a-workflow#comparing-artifacts-and-dependency-caching). Using caching was always a bit of a hack, and this change means we don't have to try to come up with unique cache keys.


For [composite actions](https://docs.github.com/en/actions/tutorials/creating-a-composite-action) (unlike reusable workflows), we can [access `github.action_path`](https://github.com/orgs/community/discussions/32593#discussioncomment-3616375) from the [`github` context](https://docs.github.com/en/actions/reference/accessing-contextual-information-about-workflow-runs#github-context), and get files from our repo that way.

## Testing

* https://github.com/guardian/etag-caching/pull/96
  * https://github.com/guardian/etag-caching/actions/runs/16073247966 ran with commit dc7b7e694019bc016940644ca4174031c8bbc144 of this PR, and succeeded - the run looks good.