### PR TITLE
Add quick script to tag new release of workflow that uses corresponding actions

### DIFF
--- a/internal/workflow-release.sh
+++ b/internal/workflow-release.sh
@@ -1,0 +1,17 @@
+VERSION=v$1
+
+echo "This script is for tagging a new release of the workflow - not for making a release of other projects!"
+
+if [ $(git tag -l "$VERSION") ]; then
+    echo "Release tag $VERSION already exists."
+    exit 1
+else
+    echo "Going for release $VERSION"
+    WORKFLOW_PATH=".github/workflows/reusable-release.yml"
+
+    sed -i '.bak' "s/@main/@$VERSION/g" $WORKFLOW_PATH && git checkout --detach && git add $WORKFLOW_PATH && git commit -m "Release $VERSION" && git tag $VERSION
+
+    git clean -f
+    git checkout main
+    git show $VERSION    
+fi


### PR DESCRIPTION
As mentioned in #69, unfortunately there's [no](https://github.com/orgs/community/discussions/18601#discussioncomment-13296390) easy way to express that a GitHub Action should run using the same commit as the reusable-workflow file that _calls_ it (tho' [it is possible for workflow-to-workflow](https://docs.github.com/en/actions/how-tos/sharing-automations/reusing-workflows#:~:text=If%20you%20use%20the%20second%20syntax%20option%20(without%20%7Bowner%7D/%7Brepo%7D%20and%20%40%7Bref%7D)%20the%20called%20workflow%20is%20from%20the%20same%20commit%20as%20the%20caller%20workflow.%20Ref%20prefixes%20such%20as%20refs/heads%20and%20refs/tags%20are%20not%20allowed.%20You%20cannot%20use%20contexts%20or%20expressions%20in%20this%20keyword.)). 

This has consequences:

* PRs that want to modify any of the 7 GitHub actions need to update ".github/workflows/reusable-release.yml" to point to the branch of the PR - ie if we are working on a PR with branch `feature-foo` we need to update all the action refs from `@main` to `@feature-foo` while we work on and test the PR - then change those refs back to `@main` before we _merge_ the PR.
* When we want to make a release - eg with release tag `v4.3.1` - we need update all the action refs from `@main` to `@v4.3.1` in a new commit (that's _not_ on `main`) and let that non-mainline commit be tagged `v4.3.1`

This PR adds a quick script for accomplishing the second of those two - making a release. It should probably become a GitHub Action workflow, but I'm happy enough to just record the process for now.
