### PR TITLE
Fix `release-type` input on push-release-commit

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -83,10 +83,11 @@ jobs:
       temporary-branch: ${{ steps.act.outputs.temporary-branch }}
     steps:
       - id: act
-        uses: guardian/gha-scala-library-release-workflow/actions/push-release-commit@main
+        uses: guardian/gha-scala-library-release-workflow/actions/push-release-commit@fix-release-type-input-on-push-release-commit
         with:
           github-app-id: ${{ inputs.GITHUB_APP_ID }}
           github-app-private-key: ${{ secrets.GITHUB_APP_PRIVATE_KEY }} }
+          release-type: ${{ needs.init.outputs.release-type }}
 
   create-artifacts:
     name: 🎊 Create artifacts
@@ -143,7 +144,7 @@ jobs:
           release-type: ${{ needs.init.outputs.release-type }}
           release-tag: ${{ needs.push-release-commit.outputs.release-tag }}
           release-version: ${{ needs.push-release-commit.outputs.release-version }}
-          release-notes-url: ${{ needs.push-release-commit.outputs.release-notes_url }}
+          release-notes-url: ${{ needs.push-release-commit.outputs.release-notes-url }}
           temporary-branch: ${{ needs.push-release-commit.outputs.temporary-branch }}
           github-app-id: ${{ inputs.GITHUB_APP_ID }}
           github-app-private-key: ${{ secrets.GITHUB_APP_PRIVATE_KEY }} }

--- a/actions/push-release-commit/action.yml
+++ b/actions/push-release-commit/action.yml
@@ -1,6 +1,9 @@
 name: '🔒 Push Release Commit'
 description: 'Push the release commit to a temporary branch'
 inputs:
+  release-type:
+    description: "Either 'FULL_MAIN_BRANCH' or 'PREVIEW_FEATURE_BRANCH'"
+    required: true
   github-app-id:
     description:
       "App ID for a GitHub App that is allowed to push directly to the default branch. Eg, App ID on:
@@ -84,6 +87,8 @@ runs:
           # Use the PR url as the release notes url when doing a 'preview' release
           RELEASE_NOTES_URL=$( gh pr view $GITHUB_REF_NAME --json url -q .url )
         fi
+        
+        echo "RELEASE_NOTES_URL=$RELEASE_NOTES_URL"
         
         VERSION_FILE_PATH=$(git diff-tree --no-commit-id --name-only -r $RELEASE_TAG | grep version.sbt)
         VERSION_FILE_INITIAL_SHA=$( git rev-parse $GITHUB_REF:$VERSION_FILE_PATH )


### PR DESCRIPTION
Sadly, on https://github.com/guardian/gha-scala-library-release-workflow/pull/69, I managed to do lots of testing of Preview releases, but not any of full-main-branch releases - consequently I missed that push-release-commit was missing an input parameter of `release-type` - I need a better linter for GitHub Actions!

The action was using `inputs.release-type`:

https://github.com/guardian/gha-scala-library-release-workflow/blob/3a3e2b0647195152992a4f528c4dc1784684e0b1/actions/push-release-commit/action.yml#L84

...but did not actually have it as an input.

Example failure:

https://github.com/guardian/etag-caching/actions/runs/16078051367/job/45377631265

## Linting

GitHub Actions is not helpful in telling you when you've misnamed inputs/outputs paramaters. Thankfully there is a program called [`actionlint`](https://github.com/rhysd/actionlint), which I should have used much earlier! 

There is an [online-playground](https://rhysd.github.io/actionlint/) for `actionlint`, which I've [used](https://rhysd.github.io/actionlint/#eJzNWFtvG0UUfu+vODQIt5FnXWhTUIQQTjCp1ZBYcVKEUGWNd8fraffGzGycgPgDPPCAeOcv8hM4Z/bitXfXdkpD8UOVzuXMuXznO+dsxENxCGOXBxxO5VRxdQsXIhBcC/g+Vm9nQbx48CCODh8ALPL/T/B0QAsAMkpSo7O/AU6Gly+ujib90Wgy/KZYBPCEdpVMjMzEFL+H/SSB4TcwixVwOJHmRToFWjNzbkBqwFfihfDAxJCkeg6eVMI1wS0tmLlAuTOeBgZQ68idOzDwu5DLXH1pbkyiD3s9X5p5OnXcOOzFyueR/JmTUrrnp1x5kkc9LYyRka97PElomWnyDAsyzzCVeeZhxTSrwiF0vnjy+dPnn3ZgD84jVJGMStGH01ur6kn+wEflTSV+StEe7xBmPMCDe+A4zjRFw2dwG6cdJSCKzcrlrt0IAljwyJATUFs8gJ4SN0kgXYm+KeWb2wQDq41Cc+yiFq4Sy1iNz8/6lz+MBpPL85eDs+ZgQWccR5wkAU9Rk8hI13oMH38rUB83DuKIaZFwxQ1G6hGarCKCVMK1Rrx4j4GV7ndRgOKBo3OhDgahl6TTQOp5zxeRICHMiu51GhxlVCry5dHJaDK6GL7qXw4mLwc/7IA1II2SucLwsUBoTSIgUfIa34S34paiZaGmpR8BV0bOuGs02RiGkv74BAz3tVOROp7HaeDBVGAeYLRUyANIAi4jI24MPOqPj4dDxlUYo/qPCRIhN12MCUmPfOgcDU6GZ1aR0dXR6fAY0BQ4Oj0/ftnpwgLBikKBe54kc1D2UX88eP6MiciNPRRQVeUScbK0EFwekVpKhPE1mjVTcQi4JG6ktk9nBlsl/MQHxgQ+wmj1S/yHSe8rK23hdeCwjF8ayRsHtXffiht3ziNf2FTivYODJwdPv+g9e/7s4OnDzYGrUMSd4jcWotTDi13tVHIZ4WLTFfHNyTqW7TG7WAUubpFXGa+c6IU84j5t5WAgL2iGwaqK2cvhuX5uZzDUg8/olyHgYtyH3BsEAbvT2ejIODVV4r0YnA4QG5NXg4vx8Lwtmx8SSNIIDRAzeYOwuBZKUzZHaTgVCuKZpZuc5LogUMunzhPn04ou1zxIkVc+/uUXeBNPtUPEXNAiy1LFyZVziuXimV9/XVOX+KdN1wE6H3XqfHt1ejr5rj88mxxd9M+OX3QAmbUzuhi8Gg6+n3w76F9eXQzKPQaLubAXLS9SEYFZipSZ6wK21qAD6lS+bpmMGkyxXIh2PKAjpDqdykywtAd///XnHzDERbum0kgzMiedppFJWYC40aYpgomfEKDYDLEhFEIsMpku2ohEO0hFpS4NR5euLTZFyGWwTYI9tLxbNbLt6rojct9lEWY6nSGy2u6unipu23OFGxhIhDleKsOCtKwPoSzQ/pw312RWdCc9vG2LOoXma7QwKmVR8ldZhfxQyeZc76xOOmslxka9tBRdvxr133+DV+VWtiOEh5rLu2OhsGyaysBjIX+DXPSGX/Mikdr8u+3evXt86ZzNfm+Ci3XXatLV8YIyGginln8j6haLLvbYnrFH9rBMIiVg7kLIb5Gq8T4xYqpTJGtq2SxrFHZ1icmzZtRgG5Cz+7LbwcSjHgzVxNtIzZoWM18Atci5j/dgHzpYAxRuVfADoTDc44Zjreewv4+1wlCVYDoRrpxJd38fHump6fmKe4F4bMOG9CbdeSGXoocC8bDQmaIx9Z77WLEU1f19mEnsdeARMnn+sIMSH8OcX2NrKkQEIXYSeN1DHSK0yBOo9y0aG2HniCHUtiJkh7LWT1feRkcgVuzNPGb2+GpZWfrANvG5vl7JyFkMibo52Cor3cKJ1lgbcVFKzi6jggar+lrJymVhF1cqmY0V3bzZsd10PmiMht38gVDw3NA1OVQ+sH2g9g27P2oM8Q/s6ONUVeaVarb/uIxv16b+a7ubCBVKTRtl3uUW4J2FkkbckSJKGub+Vqbmfp3icbQQmqWqtUTUDtZlbGGj1uq/mryM6GezhPJgveAQvlnCkV621JzyYIuM4i095zuJqpxv0yrWpkJUNtq7adlwcfmGEWESZzRvx942kevn7p38G4j5a6RtVu0YmP1egBBnDadby8WyDy/Bkn13cFY+OCx9tHaptcQ3DyMoB6qS6m1RQ62qNYiY4TSOCFaOkrWG4dgeWM6aK0RC0rtQpZMGl72+I20UTxFsPzt4rtNQt+Gn4ei9Q2jdY5u7iBYeyYKzy1zSwCsbOHJ3uQ2cSb/d2rrsmWXc79zdZb94gZW0OgU0YLY2BuB9KnK1fmqMiw3gbPBFt4b6rRBdQ9O7o4dU34yYD0wkDbPZLlGpC6gNiRvENE6JhbC7DD//khAbrhe9y+6ZtdLL3CcHtBJlJnkd5NtYkxIr/+hZKFRPsuJTaz64rCRcY6oR4P/D9FozYDdybuC2d/pkZE0pNLCfiFcBu/o5O/d5mngUpiyDaw6/srt5I1/19kZ+28npO/b7NM0GAaPve3hzZeu9hW3FB7vF7H+U1+8TPvdV15s78u1i2zr07PeBa1XLgLXdqg0DV11u64h013c2jky1d2vD3h2fWx3+/gH6Sbjx), and it can detect no further issues.

I plan to try to automate this with GitHub Actions:

https://github.com/rhysd/actionlint/blob/v1.7.7/docs/usage.md#use-actionlint-on-github-actions

## Testing

https://github.com/guardian/etag-caching/actions/runs/16142881685 ran successfully making a full main-branch release using the workflow on this PR [with](https://github.com/guardian/etag-caching/actions/runs/16142881685/job/45554402374#step:1:27) commit 1d9d4b3827df060e72b7b10155a9921e700e110.
