### PR TITLE
Add lint check for calls to internal GitHub Actions using a different branch

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,70 @@
+name: Lint
+on:
+  workflow_dispatch:
+  pull_request:
+
+  # triggering CI default branch improves caching
+  # see https://docs.github.com/en/free-pro-team@latest/actions/guides/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache
+  push:
+    branches:
+      - main
+
+jobs:
+  internal-action-branch-check:
+    name: Branch check for calls to the workflow's internal GitHub Actions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check for calls to the workflow's internal GitHub Actions incorrectly using a different branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          cd `mktemp -d`
+          
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            export short_ref="${{ github.event.pull_request.head.ref }}"
+          else
+            export short_ref="${{ github.ref_name }}"
+          fi
+          workflow_file=".github/workflows/reusable-release.yml"
+
+          echo "short_ref=$short_ref"
+          yq '[.jobs.*.steps[]
+              | select(has("uses"))
+              | .uses
+              | {"call": capture("gha-scala-library-release-workflow/actions/(?P<action>.*)@(?P<ref>.*)"), "line": line}
+              | select(.call.ref != strenv(short_ref))
+              | [.call.action, .call.ref, .line] ]' -o csv $GITHUB_WORKSPACE/$workflow_file | grep . > differing-action-refs.csv
+          
+          printf "\n* Calls to GitHub Actions where the ref is not our current branch...\n"
+          cat differing-action-refs.csv
+          
+          # If we're the default branch, everything should be the default branch.
+          # If we're PR, refs to altered actions must match the branch.
+          
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            gh pr diff $short_ref --name-only | grep "^actions/" | cut -d'/' -f2 | sort | uniq > modified-actions.txt
+          
+            printf "\n* Actions modified by this PR:\n"
+            cat modified-actions.txt
+            
+            touch errors.csv
+            while read -r MODIFIED_ACTION; do
+              grep "^$MODIFIED_ACTION," differing-action-refs.csv >> errors.csv || true
+            done < modified-actions.txt
+          else
+            cp differing-action-refs.csv errors.csv
+          fi
+          
+          printf "\n* Gathered errors:\n"
+          cat errors.csv
+          
+          while IFS=',' read -r action ref line; do
+            echo "::error file=$workflow_file,line=$line,title=Mismatched call (using branch '$ref') to internal GitHub Action '$action'::On the '$short_ref' branch, calls to the workflow's internal GitHub Action '$action' should use '$short_ref', not '$ref'"
+          done < errors.csv
+
+          if [ -s "errors.csv" ]; then
+            echo "❌ The workflow is referring to internal actions on a different branch." >&2
+            exit 1
+          fi

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -83,7 +83,7 @@ jobs:
       temporary-branch: ${{ steps.act.outputs.temporary-branch }}
     steps:
       - id: act
-        uses: guardian/gha-scala-library-release-workflow/actions/push-release-commit@fix-release-type-input-on-push-release-commit
+        uses: guardian/gha-scala-library-release-workflow/actions/push-release-commit@main
         with:
           github-app-id: ${{ inputs.GITHUB_APP_ID }}
           github-app-private-key: ${{ secrets.GITHUB_APP_PRIVATE_KEY }} }


### PR DESCRIPTION
Ever since PR https://github.com/guardian/gha-scala-library-release-workflow/pull/69, we've had to be careful that calls by the `reusable-release.yml` workflow to its internal GitHub Actions are specifying the _same_ branch that we're working on - and it's easy to forget that, as we switch from `main` to feature-branches and back again.

For instance, this is a git commit on the `main` branch, accidentally referring to another branch entirely:

https://github.com/guardian/gha-scala-library-release-workflow/blob/69b8f74c92fcf478302f1d9775c784e8b680a943/.github/workflows/reusable-release.yml#L86

### What does this PR change?

This PR introduces a new check to ensure that all the calls to GitHub Actions made by `reusable-release.yml` are following these rules:

* If we're on the `main` branch, all internal actions should be called with a ref of `@main`
* If we're on a PR, any call to a _modified_ action must be using the PR branch

### Testing

* https://github.com/guardian/gha-scala-library-release-workflow/pull/74 - this PR fails correctly, but as it does not modify the `.github/workflows/reusable-release.yml` file (when it _should_, to use the correct branch!), unfortunately the helpful annotations against that file aren't displayed inline - GitHub won't display the file at all if it isn't modified, and it won't annotate it either.
* https://github.com/guardian/gha-scala-library-release-workflow/pull/76

<img width="678" height="116" alt="image" src="https://github.com/user-attachments/assets/fd783209-0ae9-4bb5-92e9-8372847dabba" />

### Extracting this new check so it can be used by other workflows...

The new [`gha-gradle-library-release-workflow`](https://github.com/guardian/gha-gradle-library-release-workflow) (based on `gha-scala-library-release-workflow`) may want to use a check like this - we can probably extract the logic here if so, to leave something like:

```yaml
      - uses: guardian/gha-workflow-checks/actions/check-internal-action-refs
        with:
          workflow-file: ".github/workflows/reusable-release.yml" # maybe examine everything in /workflows/?
          actions-folder: "actions" # default to "actions" to encourage consistency
```

