### PR TITLE
Make commit of post release SNAPSHOT version optional (defaults to commit)

### DIFF
--- a/actions/update-github/action.yml
+++ b/actions/update-github/action.yml
@@ -38,7 +38,7 @@ inputs:
   commit-snapshot-version:
     description: "If true, the action will commit the post-release version file with a message indicating that it is a snapshot version"
     required: false
-    default: 'true
+    default: 'true'
 
 runs:
   using: "composite"


### PR DESCRIPTION
## What does this change?

The PR adds a new input `commit-snapshot-version` to the `update-github` action that allows us to configure whether or not to commit a post-release `-SNAPSHOT` version.

This change will allow us to reuse this workflow in repos where we don't want a `-SNAPSHOT` version post release. Specifically, this allows reusing this action in [the Gradle library release workflow](https://github.com/guardian/gha-gradle-library-release-workflow). There's a draft PR updating the Gradle workflow here: https://github.com/guardian/gha-gradle-library-release-workflow/pull/4

Users of the Scala workflow should remain unaffected due to the default true behaviour for the configuring input.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test


## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
