### PR TITLE
Fix `grep`-related failure that occurs when there are NO differing-action-refs

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -43,7 +43,7 @@ jobs:
               | .uses
               | {"call": capture("gha-scala-library-release-workflow/actions/(?P<action>.*)@(?P<ref>.*)"), "line": line}
               | select(.call.ref != strenv(short_ref))
-              | [.call.action, .call.ref, .line] ]' -o csv $absolute_path_to_workflow_file | grep . > differing-action-refs.csv
+              | [.call.action, .call.ref, .line] ]' -o csv $absolute_path_to_workflow_file | grep . > differing-action-refs.csv || true
           
           printf "\n* Calls to GitHub Actions where the ref is not our current branch...\n"
           cat differing-action-refs.csv


### PR DESCRIPTION
This fixes a bug in the work from:

* https://github.com/guardian/gha-scala-library-release-workflow/pull/73

Composite GitHub Actions seem to die when any line in the bash script returns a non-zero exit code. Unfortunately, that's exactly what `grep` does when it finds zero matches - and in this workflow at least, we _don't_ want it to die if it can't find any matches - ie if there are no differing-action-refs:

https://github.com/guardian/gha-scala-library-release-workflow/blob/d4782815bfbfa974017d4a968800421a85e4c1aa/.github/workflows/linter.yml#L46

...that's an ok situation, we do not want the lack of any matches to cause `grep` to kill the job.

The fix is to stick a ` || true` on the end of the line - like we've already done elsewhere:

https://github.com/guardian/gha-scala-library-release-workflow/blob/d4782815bfbfa974017d4a968800421a85e4c1aa/.github/workflows/linter.yml#L62

This behaviour by `grep` & GitHub Actions is a bit insidious! This never would have happened if I'd written this script in pure Scala, etc, etc...!

Error first noticed with https://github.com/guardian/gha-scala-library-release-workflow/pull/73#issuecomment-3083549787

## Testing

The `main` branch is the only place where we've seen this failure so far, so I'm going to merge this PR straight away, to demonstrate that it fixes the problem.
