### PR TITLE
Compatibility-checking for single-module projects: update docs to specify correct `sbt-version-policy` `ReleaseVersion` method

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -121,12 +121,13 @@ Minimum `sbt` version: [**1.9.0**](https://github.com/sbt/sbt/releases/tag/v1.9.
     `checkSnapshotDependencies, inquireVersions, runClean, runTest, setReleaseVersion, commitReleaseVersion, tagRelease, setNextVersion, commitNextVersion`
     _([if your tests require special privileges](https://github.com/guardian/facia-scala-client/pull/299/files#r1425649126)
     you may need to drop `runTest`)_
-  * `releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value` - to activate the
-      automatic compatibility-based version-numbering provided by the `sbt-version-policy` plugin. This means your `version`
-      can go up by more than just an `x.x.PATCH` increment in a release, if
-      [Scala semver rules](https://www.scala-lang.org/blog/2021/02/16/preventing-version-conflicts-with-versionscheme.html#early-semver-and-sbt-version-policy)
-      say that it should. You'll need `import sbtversionpolicy.withsbtrelease.ReleaseVersion` at the top of your  `build.sbt`
-      to access this method.
+  * **Enable automated compatibility-based versioning** by updating the `releaseVersion` setting. The correct version
+    bump will be calculated by the `sbt-version-policy` plugin - your `version` can go up by more than just an
+    `x.x.PATCH` increment in a release, if [Scala semver rules](https://www.scala-lang.org/blog/2021/02/16/preventing-version-conflicts-with-versionscheme.html#early-semver-and-sbt-version-policy) say that it should. You'll need to
+    `import sbtversionpolicy.withsbtrelease.ReleaseVersion` at the top of your `build.sbt`, and then use **one** of the
+    following two methods, depending on whether your project is multi-module or not:
+    * **Multi-module** : `releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value`
+    * **Single-module** : `releaseVersion := ReleaseVersion.fromAssessedCompatibilityWithLatestRelease().value`
 
 ### Unnecessary `sbt` plugins
 


### PR DESCRIPTION
After this recent PR, we noticed that _despite_ breaking compatibility (changing method signatures), the release only had a tiny PATCH-level bump (to [v1.0.3](https://github.com/guardian/fastly-api-client/releases/tag/v1.0.3)):

* https://github.com/guardian/fastly-api-client/pull/64

This was because the project was using the wrong compatibility-assessment method for _single_-module projects - something we really hadn't been thinking about. For some technical reason, the `sbt-version-policy` plugin requires us to use a different method, depending on whether or not the project is a single-module project, or an aggregated multi-module project (this is documented [here](https://github.com/scalacenter/sbt-version-policy?tab=readme-ov-file#unconstrained-compatibility-level)):

**Single-module projects**

```
ReleaseVersion.fromAssessedCompatibilityWithLatestRelease()
```

**Multi-module projects**

```
ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease()
```

If, as in the case of `fastly-api-client`, you use the single-module form when you should be using the multi-module form, the version calculation will just give you PATCH version bumps, even if you break compatibility in many ways.

The projects that are single-module and therefore need updating can be found with this GH search query:

https://github.com/search?q=path%3A**%2Fbuild.sbt+org%3Aguardian+fromAggregatedAssessedCompatibilityWithLatestRelease+NOT+.aggregate&type=code&ref=advsearch
