### PR TITLE
Document bug in GitHub UI granting repo access to GitHub App

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,10 +10,11 @@ The release workflow needs a `release.yml` GitHub workflow in your repo, and spe
 
 ## Repo settings
 
-* Ensure [your GitHub App](github-app.md) has access to your repo. **Guardian developers:** click
-  `Configure` on the [gu-scala-library-release](https://github.com/apps/gu-scala-library-release) app -
-  so long as you have admin permissions on your repo, you should be able to add your repo to the list
-  of selected repositories.
+* Ensure [your GitHub App](github-app.md) has access to your repo. **Guardian developers:** Get an org-owner to click
+  `Configure` on the [gu-scala-library-release](https://github.com/apps/gu-scala-library-release) app and grant access to the repo -
+  usually just having admin permissions on the repo would be enough to reliably add your repo to the list
+  of selected repositories, but as of December 2025, we've found that if a user does not have org-owner rights,
+  add repositories can actually unintentionally _remove_ repos.
 * **Guardian developers:** Comply with the repository requirements of [`guardian/github-secret-access`](https://github.com/guardian/github-secret-access?tab=readme-ov-file#repo-requirements),
   i.e. ensure the repository has a `production` Topic label.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,7 +14,7 @@ The release workflow needs a `release.yml` GitHub workflow in your repo, and spe
   `Configure` on the [gu-scala-library-release](https://github.com/apps/gu-scala-library-release) app and grant access to the repo -
   usually just having admin permissions on the repo would be enough to reliably add your repo to the list
   of selected repositories, but as of December 2025, we've found that if a user does not have org-owner rights,
-  add repositories can actually unintentionally _remove_ repos.
+  adding repositories can actually unintentionally _remove_ repos.
 * **Guardian developers:** Comply with the repository requirements of [`guardian/github-secret-access`](https://github.com/guardian/github-secret-access?tab=readme-ov-file#repo-requirements),
   i.e. ensure the repository has a `production` Topic label.
 


### PR DESCRIPTION
It's not currently safe for devs who are not org-owners to add any selected-repos for GitHub App permissions. See https://chat.google.com/room/AAAAag0I08g/eII3X81toe0/eII3X81toe0 .

From GitHub:

> We truly apologise for the inconvenience. We've had a handful reports of similar behaviour from other customers and the issue was recently escalated to GitHub's engineering team. Our engineers have confirmed a bug that may unintentionally revoke an app’s repository access during access updates, even when those repositories were not intended to be affected. The team are actively working on major architectural changes to resolve this issue and several others. Currently, we're unable to share any exact ETAs; however, our team have indicated they're aiming to deliver this work by year-end.
