### PR TITLE
Configure Dependabot to update all GitHub Action files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,8 @@
 version: 2
 updates:
   - package-ecosystem: 'github-actions'
-    directory: '/'
+    directories:
+      - "/"
+      - "/actions/*"
     schedule:
       interval: 'weekly'


### PR DESCRIPTION
Dependabot hasn't been updating the many GitHub Actions we define in the `/actions/` folder (introduced with https://github.com/guardian/gha-scala-library-release-workflow/pull/69 in July 2025), as remarked upon in [this comment](https://github.com/guardian/gha-scala-library-release-workflow/pull/84/changes#r2568383349) - [that Dependabot PR](https://github.com/guardian/gha-scala-library-release-workflow/pull/84) was only updating `.github/workflows/linter.yml`, probably the least important file to update!

Hopefully this config change, suggested by @andrew-nowak, should make the difference - rather than [specifying `/`](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#directories-or-directory--:~:text=Dependabot%20will%20search%20the%20/.github/workflows%20directory), lets specify the _parent folders_ of all the action files, as Dependabot will hopefully look for the `action.yml` files inside, as perhaps implied by the docs:

> For GitHub Actions, use the value `/`. Dependabot will search the `/.github/workflows` directory, as well as the `action.yml`/`action.yaml` file from the root directory.

We're switching to use the [`directories`](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#directories-or-directory--) (rather than `directory`) key to [specify multiple locations](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/manage-your-dependency-security/controlling-dependencies-updated#defining-multiple-locations-for-manifest-files) - the key supports globbing and the wildcard character `*`.


