### PR TITLE
Grouping works!

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,9 @@ updates:
     schedule:
       interval: 'weekly'
     groups:
-      setup-java:
-        patterns:
-          - "actions/setup-java"
-      checkout:
-        patterns:
-          - "actions/checkout"
+      actions/setup-java: { patterns: ["actions/setup-java"] }
+      actions/checkout: { patterns: ["actions/checkout"] }
+      actions/upload-artifact: { patterns: [ "actions/upload-artifact" ] }
+      sbt/setup-sbt: { patterns: ["sbt/setup-sbt"] }
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
We proved it works with #103! This produced PRs like https://github.com/guardian/gha-scala-library-release-workflow/pull/105

<img width="840" height="589" alt="image" src="https://github.com/user-attachments/assets/fba3934f-930b-44ae-999f-ff17f9451149" />
