### PR TITLE
Remind people to check out latest main in release instructions

### DIFF
--- a/docs/releasing-a-new-version-of-this-workflow.md
+++ b/docs/releasing-a-new-version-of-this-workflow.md
@@ -4,33 +4,35 @@ This guide is for releasing a new version of the gha-scala-library-release-workf
 
 ## Process
 
-1. Choose a version number for your release using [Semantic Versioning](https://semver.org/)
+1. Check out latest main
+
+2. Choose a version number for your release using [Semantic Versioning](https://semver.org/)
 
    - The [releases page for this repository](https://github.com/guardian/gha-scala-library-release-workflow/releases) may be helpful for deciding on your new release version
 
-2. Call [workflow-release.sh](../internal/workflow-release.sh) with your chosen version number. For example, if your chosen version number was 2.0.4, you would run:
+3. Call [workflow-release.sh](../internal/workflow-release.sh) with your chosen version number. For example, if your chosen version number was 2.0.4, you would run:
 
    ```sh
    ./internal/workflow-release.sh 2.0.4
    ```
 
-3. Push the tag the script has created:
+4. Push the tag the script has created:
 
    ```sh
    git push origin v2.0.4
    ```
 
-4. Update the major version tag to point to the new minor version:
+5. Update the major version tag to point to the new minor version:
 
    ```sh
    git tag -f v2 v2.0.4 && git push -f origin v2
    ```
 
-5. [Draft a new release](https://github.com/guardian/gha-scala-library-release-workflow/releases/new) in the github UI
+6. [Draft a new release](https://github.com/guardian/gha-scala-library-release-workflow/releases/new) in the github UI
 
    - select your new tag
    - manually select the previous tag (because auto will fail)
    - click Generate Release Notes
    - click Publish Release
 
-6. Confirm the major version tag points to the same commit as the new minor version tag
+7. Confirm the major version tag points to the same commit as the new minor version tag


### PR DESCRIPTION
## What does this change?

@kelvin-chappell and I recently followed these release instructions when creating https://github.com/guardian/gha-scala-library-release-workflow/releases/tag/v2.0.8 but forgot to check out latest main. As a result the release missed some changes we intended to include, which we then included in a fresh release, https://github.com/guardian/gha-scala-library-release-workflow/releases/tag/v2.0.9

I think if the instructions had contained this initial reminder, we wouldn’t have missed the changes.