### PR TITLE
Change recommendation in case of failed release

### DIFF
--- a/docs/making-a-release.md
+++ b/docs/making-a-release.md
@@ -55,12 +55,7 @@ notes, as part of the release process, so a GitHub Release is still created with
 If the release fails after it's tagged the repo, or it's a new artifact, subsequent releases will search for that non existent version in
 maven central when trying to do the compatibility check.
 
-If it's due to a failed release:
-1. delete the Release and Tag from the github UI,
-1. revert the edit to the version.sbt.
-1. run the release action again
-
-If it's a new artifact e.g. first scala 3 version:
+If it's due to a failed release or a new artifact e.g. first scala 3 version:
 1. update the version.sbt manually to be a suitable SNAPSHOT version (usually a major version)
 1. comment out the version check in the build.sbt
 1. run the release action again


### PR DESCRIPTION
Our organisation sensibly does not all pushing a new version for a tag that has previously existed, so attempting to re-release the same version of a library will fail.
