### PR TITLE
Revert GitHub Action version numbers that are too precise

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -14,7 +14,7 @@ jobs:
     name: Branch check for calls to the workflow's internal GitHub Actions
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v6
       - name: Check for calls to the workflow's internal GitHub Actions incorrectly using a different branch
         env:
           GH_TOKEN: ${{ github.token }}

--- a/actions/create-artifacts/action.yml
+++ b/actions/create-artifacts/action.yml
@@ -22,7 +22,7 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@v6
       with:
         ref: ${{ inputs.release-commit-id }}
     - uses: actions/setup-java@v5 # don't 'cache: sbt', at least until https://github.com/actions/setup-java/pull/564 is resolved

--- a/actions/push-release-commit/action.yml
+++ b/actions/push-release-commit/action.yml
@@ -48,7 +48,7 @@ runs:
       with:
         app-id: ${{ inputs.github-app-id }}
         private-key: ${{ inputs.github-app-private-key }} }
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@v6
       with:
         path: repo
     - uses: actions/download-artifact@v8

--- a/actions/sign/action.yml
+++ b/actions/sign/action.yml
@@ -42,7 +42,7 @@ runs:
       with:
         app-id: ${{ inputs.github-app-id }}
         private-key: ${{ inputs.github-app-private-key }} }
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@v6
       with:
         path: repo
         ref: ${{ inputs.release-commit-id }}

--- a/actions/versioning/action.yml
+++ b/actions/versioning/action.yml
@@ -12,7 +12,7 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@v6
     - id: establish_java_for_library_build
       name: Establish library build Java version
       shell: bash


### PR DESCRIPTION
This reverts PR #130, ie commit 3c485d48094ee5d39329d8bc5b99c962d82a6122.

See https://github.com/guardian/gha-scala-library-release-workflow/pull/130#discussion_r3419573835

If we _are_ using git tags to specify GitHub Action versions (ie, because we do _trust_ the repo they come, as they are official repos maintained by GitHub, and we _have_ to trust GitHub already), then I feel like we should get the benefit of just getting the latest versions released for that major version, without having to look at extra PRs like #132.

How do we stop dependabot raising PRs that switch us from just-the-major-version to fully-specified-patch-version ...? I'm not sure - this may be a bug regression in Dependabot itself:

* https://github.com/dependabot/dependabot-core/pull/4953
* https://github.com/dependabot/dependabot-core/issues/5887#issuecomment-4717148471
* https://github.com/dependabot/dependabot-core/pull/5891
* https://github.com/dependabot/dependabot-core/pull/6102
