### PR TITLE
Use `client-id` rather than deprecated `app-id` for `create-github-app-token`

### DIFF
--- a/actions/push-release-commit/action.yml
+++ b/actions/push-release-commit/action.yml
@@ -46,7 +46,7 @@ runs:
     - id: generate-github-app-token
       uses: actions/create-github-app-token@v3
       with:
-        app-id: ${{ inputs.github-app-id }}
+        client-id: ${{ inputs.github-app-id }}
         private-key: ${{ inputs.github-app-private-key }} }
     - uses: actions/checkout@v6
       with:

--- a/actions/sign/action.yml
+++ b/actions/sign/action.yml
@@ -40,7 +40,7 @@ runs:
     - id: generate-github-app-token
       uses: actions/create-github-app-token@v3
       with:
-        app-id: ${{ inputs.github-app-id }}
+        client-id: ${{ inputs.github-app-id }}
         private-key: ${{ inputs.github-app-private-key }} }
     - uses: actions/checkout@v6
       with:

--- a/actions/update-github/action.yml
+++ b/actions/update-github/action.yml
@@ -43,7 +43,7 @@ runs:
     - id: generate-github-app-token
       uses: actions/create-github-app-token@v3
       with:
-        app-id: ${{ inputs.github-app-id }}
+        client-id: ${{ inputs.github-app-id }}
         private-key: ${{ inputs.github-app-private-key }} }
     - name: Add common values to the GITHUB_ENV - note all subsequent steps have access to the GitHub token with GH_TOKEN
       shell: bash


### PR DESCRIPTION
`app-id` was deprecated in GitHub Action [`create-github-app-token`](https://github.com/actions/create-github-app-token) with this change:

* https://github.com/actions/create-github-app-token/pull/353
* https://github.com/actions/create-github-app-token/issues/252

We've been seeing these warnings while [making releases](https://github.com/guardian/facia-scala-client/actions/runs/31004784394):

```
release / 🔒 Push Release Commit
Input 'app-id' has been deprecated with message: Use 'client-id' instead.
release / 🔒 Sign
Input 'app-id' has been deprecated with message: Use 'client-id' instead.
release / 🔒 Update GitHub
Input 'app-id' has been deprecated with message: Use 'client-id' instead.
```

I think we can [disregard the lint-check](https://github.com/guardian/gha-scala-library-release-workflow/blob/main/docs/linting-workflow-action-branch-refs.md#can-you-ignore-linting-errors) for this change.

