### PR TITLE
Update setup-sbt to v1.5.8 to fix ampel breakage

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -44,7 +44,7 @@ jobs:
       version-suffix: ${{ steps.act.outputs.version-suffix }}
     steps:
       - id: act
-        uses: guardian/gha-scala-library-release-workflow/actions/init@update-setup-sbt-to-fix-ampel-breakage
+        uses: guardian/gha-scala-library-release-workflow/actions/init@main
         with:
           pgp-private-key: ${{ secrets.PGP_PRIVATE_KEY }}
 
@@ -56,7 +56,7 @@ jobs:
       library-build-major-java-version: ${{ steps.act.outputs.library-build-major-java-version }}
     steps:
       - id: act
-        uses: guardian/gha-scala-library-release-workflow/actions/versioning@update-setup-sbt-to-fix-ampel-breakage
+        uses: guardian/gha-scala-library-release-workflow/actions/versioning@main
         with:
           version-suffix: ${{ needs.init.outputs.version-suffix }}
 
@@ -83,7 +83,7 @@ jobs:
       temporary-branch: ${{ steps.act.outputs.temporary-branch }}
     steps:
       - id: act
-        uses: guardian/gha-scala-library-release-workflow/actions/push-release-commit@update-setup-sbt-to-fix-ampel-breakage
+        uses: guardian/gha-scala-library-release-workflow/actions/push-release-commit@main
         with:
           github-app-id: ${{ inputs.GITHUB_APP_ID }}
           github-app-private-key: ${{ secrets.GITHUB_APP_PRIVATE_KEY }} }
@@ -97,7 +97,7 @@ jobs:
       artifact-sha256sums: ${{ steps.act.outputs.artifact-sha256sums }}
     steps:
       - id: act
-        uses: guardian/gha-scala-library-release-workflow/actions/create-artifacts@update-setup-sbt-to-fix-ampel-breakage
+        uses: guardian/gha-scala-library-release-workflow/actions/create-artifacts@main
         with:
           release-commit-id: ${{ needs.push-release-commit.outputs.release-commit-id }}
           release-notes-url: ${{ needs.push-release-commit.outputs.release-notes-url }}
@@ -109,7 +109,7 @@ jobs:
     needs: [init, push-release-commit, create-artifacts]
     runs-on: ubuntu-latest
     steps:
-      - uses: guardian/gha-scala-library-release-workflow/actions/sign@update-setup-sbt-to-fix-ampel-breakage
+      - uses: guardian/gha-scala-library-release-workflow/actions/sign@main
         with:
           github-app-id: ${{ inputs.GITHUB_APP_ID }}
           github-app-private-key: ${{ secrets.GITHUB_APP_PRIVATE_KEY }} }
@@ -126,7 +126,7 @@ jobs:
     needs: [push-release-commit, sign]
     runs-on: ubuntu-latest
     steps:
-      - uses: guardian/gha-scala-library-release-workflow/actions/sonatype-release@update-setup-sbt-to-fix-ampel-breakage
+      - uses: guardian/gha-scala-library-release-workflow/actions/sonatype-release@main
         with:
           release-version: ${{ needs.push-release-commit.outputs.release-version }}
           sonatype-token: ${{ secrets.SONATYPE_TOKEN }}
@@ -139,7 +139,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: guardian/gha-scala-library-release-workflow/actions/update-github@update-setup-sbt-to-fix-ampel-breakage
+      - uses: guardian/gha-scala-library-release-workflow/actions/update-github@main
         with:
           release-type: ${{ needs.init.outputs.release-type }}
           release-tag: ${{ needs.push-release-commit.outputs.release-tag }}

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -44,7 +44,7 @@ jobs:
       version-suffix: ${{ steps.act.outputs.version-suffix }}
     steps:
       - id: act
-        uses: guardian/gha-scala-library-release-workflow/actions/init@main
+        uses: guardian/gha-scala-library-release-workflow/actions/init@update-setup-sbt-to-fix-ampel-breakage
         with:
           pgp-private-key: ${{ secrets.PGP_PRIVATE_KEY }}
 
@@ -56,7 +56,7 @@ jobs:
       library-build-major-java-version: ${{ steps.act.outputs.library-build-major-java-version }}
     steps:
       - id: act
-        uses: guardian/gha-scala-library-release-workflow/actions/versioning@main
+        uses: guardian/gha-scala-library-release-workflow/actions/versioning@update-setup-sbt-to-fix-ampel-breakage
         with:
           version-suffix: ${{ needs.init.outputs.version-suffix }}
 
@@ -83,7 +83,7 @@ jobs:
       temporary-branch: ${{ steps.act.outputs.temporary-branch }}
     steps:
       - id: act
-        uses: guardian/gha-scala-library-release-workflow/actions/push-release-commit@main
+        uses: guardian/gha-scala-library-release-workflow/actions/push-release-commit@update-setup-sbt-to-fix-ampel-breakage
         with:
           github-app-id: ${{ inputs.GITHUB_APP_ID }}
           github-app-private-key: ${{ secrets.GITHUB_APP_PRIVATE_KEY }} }
@@ -97,7 +97,7 @@ jobs:
       artifact-sha256sums: ${{ steps.act.outputs.artifact-sha256sums }}
     steps:
       - id: act
-        uses: guardian/gha-scala-library-release-workflow/actions/create-artifacts@main
+        uses: guardian/gha-scala-library-release-workflow/actions/create-artifacts@update-setup-sbt-to-fix-ampel-breakage
         with:
           release-commit-id: ${{ needs.push-release-commit.outputs.release-commit-id }}
           release-notes-url: ${{ needs.push-release-commit.outputs.release-notes-url }}
@@ -109,7 +109,7 @@ jobs:
     needs: [init, push-release-commit, create-artifacts]
     runs-on: ubuntu-latest
     steps:
-      - uses: guardian/gha-scala-library-release-workflow/actions/sign@main
+      - uses: guardian/gha-scala-library-release-workflow/actions/sign@update-setup-sbt-to-fix-ampel-breakage
         with:
           github-app-id: ${{ inputs.GITHUB_APP_ID }}
           github-app-private-key: ${{ secrets.GITHUB_APP_PRIVATE_KEY }} }
@@ -126,7 +126,7 @@ jobs:
     needs: [push-release-commit, sign]
     runs-on: ubuntu-latest
     steps:
-      - uses: guardian/gha-scala-library-release-workflow/actions/sonatype-release@main
+      - uses: guardian/gha-scala-library-release-workflow/actions/sonatype-release@update-setup-sbt-to-fix-ampel-breakage
         with:
           release-version: ${{ needs.push-release-commit.outputs.release-version }}
           sonatype-token: ${{ secrets.SONATYPE_TOKEN }}
@@ -139,7 +139,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: guardian/gha-scala-library-release-workflow/actions/update-github@main
+      - uses: guardian/gha-scala-library-release-workflow/actions/update-github@update-setup-sbt-to-fix-ampel-breakage
         with:
           release-type: ${{ needs.init.outputs.release-type }}
           release-tag: ${{ needs.push-release-commit.outputs.release-tag }}

--- a/actions/create-artifacts/action.yml
+++ b/actions/create-artifacts/action.yml
@@ -29,7 +29,7 @@ runs:
       with:
         distribution: corretto
         java-version: ${{ inputs.library-build-major-java-version }}
-    - uses: sbt/setup-sbt@f6db8ab474efba716fc7f04441ab33714e4825af # v1.5.4
+    - uses: sbt/setup-sbt@c7d2d6258b4bd0d3ec5129e6b3453199d3c79729 # v1.5.8
     - name: Generate artifacts
       shell: bash
       env:

--- a/actions/sonatype-release/action.yml
+++ b/actions/sonatype-release/action.yml
@@ -36,7 +36,7 @@ runs:
         distribution: corretto
         java-version: 21
         cache: sbt # the issue described in https://github.com/actions/setup-java/pull/564 doesn't affect this step (no version.sbt)
-    - uses: sbt/setup-sbt@f6db8ab474efba716fc7f04441ab33714e4825af # v1.5.4
+    - uses: sbt/setup-sbt@c7d2d6258b4bd0d3ec5129e6b3453199d3c79729 # v1.5.8
     - name: Release
       shell: bash
       run: |

--- a/actions/versioning/action.yml
+++ b/actions/versioning/action.yml
@@ -35,7 +35,7 @@ runs:
       with:
         distribution: corretto
         java-version: ${{ steps.establish_java_for_library_build.outputs.library-build-major-java-version }}
-    - uses: sbt/setup-sbt@f6db8ab474efba716fc7f04441ab33714e4825af # v1.5.4
+    - uses: sbt/setup-sbt@c7d2d6258b4bd0d3ec5129e6b3453199d3c79729 # v1.5.8
     - name: Use sbt-release to construct version.sbt updates
       shell: bash
       run: |


### PR DESCRIPTION
## What does this change?

Currently, the workflow fails due to how setup-sbt installs ampel (see https://github.com/guardian/gha-scala-library-release-workflow/issues/150).

This pull request updates setup-sbt to the latest version, in the hope that picking up https://github.com/sbt/setup-sbt/pull/119 (where it updates its dependency on the action it uses to install ampel) will resolve our issue.

Hopefully fixes #150

## How has this change been tested?

I have tested on play-secret-rotation by creating [this PR](https://github.com/guardian/play-secret-rotation/pull/624) and running the release workflow on that branch, producing [this action run](https://github.com/guardian/play-secret-rotation/actions/runs/32867840247) which got past the versioning step.